### PR TITLE
Use the reference implementation of JSR-353

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
             <name>John E. Vincent</name>
             <email>lusis.org+github.com@gmail.com</email>
         </developer>
+        <developer>
+            <id>datenbrille</id>
+            <name>Karl Spies</name>
+            <email>Karl.Spies@synaxon.de</email>
+        </developer>
     </developers>
 
     <dependencies>
@@ -71,19 +76,14 @@
             <version>${ch.qos.logback.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${com.fasterxml.jackson.version}</version>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.0-b06</version>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons.io.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons.lang.version}</version>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.0-b06</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -1,98 +1,114 @@
 /**
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
  */
 package net.logstash.logback.encoder;
-
-import static org.apache.commons.io.IOUtils.*;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.apache.commons.lang.time.FastDateFormat;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.encoder.EncoderBase;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.json.Json;
+import javax.json.JsonBuilderFactory;
+import javax.json.JsonObjectBuilder;
 
-import com.fasterxml.jackson.core.JsonGenerator.Feature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
+/**
+ * Log encoder for logstash to produce json log event via layouter.
+ */
 public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
-    
-    private static final ObjectMapper MAPPER = new ObjectMapper().configure(Feature.ESCAPE_NON_ASCII, true);
-    private static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
-    
+
+    private static final JsonBuilderFactory BUILDER = Json.createBuilderFactory(null);
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
     private boolean immediateFlush = true;
-    
+    private static String hostname;
+
+    static {
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            hostname = "unknown-host";
+        }
+    }
+
     @Override
     public void doEncode(ILoggingEvent event) throws IOException {
-        
-        ObjectNode eventNode = MAPPER.createObjectNode();
-        eventNode.put("@timestamp", ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(event.getTimeStamp()));
-        eventNode.put("@message", event.getFormattedMessage());
-        eventNode.put("@fields", createFields(event));
-        
-        write(MAPPER.writeValueAsBytes(eventNode), outputStream);
-        write(CoreConstants.LINE_SEPARATOR, outputStream);
-        
+
+        JsonObjectBuilder builder = BUILDER.createObjectBuilder();
+        builder.add("@timestamp", DATE_FORMAT.format(event.getTimeStamp()));
+        builder.add("@message", event.getFormattedMessage());
+        builder.add("@source", event.getLoggerName());
+        builder.add("@source_host", hostname);
+        builder.add("@fields", createFields(event));
+
+        outputStream.write(builder.build().toString().getBytes());
+        outputStream.write(CoreConstants.LINE_SEPARATOR.getBytes());
+
         if (immediateFlush) {
             outputStream.flush();
         }
-        
+
     }
-    
-    private ObjectNode createFields(ILoggingEvent event) {
-        
-        ObjectNode fieldsNode = MAPPER.createObjectNode();
-        fieldsNode.put("logger_name", event.getLoggerName());
-        fieldsNode.put("thread_name", event.getThreadName());
-        fieldsNode.put("level", event.getLevel().toString());
-        fieldsNode.put("level_value", event.getLevel().toInt());
-        
+
+    private JsonObjectBuilder createFields(ILoggingEvent event) {
+
+        JsonObjectBuilder builder = BUILDER.createObjectBuilder();
+        builder.add("logger_name", event.getLoggerName());
+        builder.add("thread_name", event.getThreadName());
+        builder.add("level", event.getLevel().toString());
+        builder.add("level_value", event.getLevel().toInt());
+
         IThrowableProxy throwableProxy = event.getThrowableProxy();
         if (throwableProxy != null) {
-            fieldsNode.put("stack_trace", ThrowableProxyUtil.asString(throwableProxy));
+            builder.add("stack_trace", ThrowableProxyUtil.asString(throwableProxy));
         }
-        
+
         Map<String, String> mdc = event.getMDCPropertyMap();
-        
+
         if (mdc != null) {
             for (Entry<String, String> entry : mdc.entrySet()) {
                 String key = entry.getKey();
                 String value = entry.getValue();
-                fieldsNode.put(key, value);
+                builder.add(key, value);
             }
         }
-        
-        return fieldsNode;
-        
+
+        return builder;
+
     }
-    
+
     @Override
     public void close() throws IOException {
-        write(LINE_SEPARATOR, outputStream);
+        outputStream.write(CoreConstants.LINE_SEPARATOR.getBytes());
     }
-    
+
+    /**
+     * If true the outputstream will flushed immediatly.
+     *
+     * @return true if stream will be flushed immediatly
+     */
     public boolean isImmediateFlush() {
         return immediateFlush;
     }
-    
+
+    /**
+     * Set to true to flush outputstream immediatly.
+     *
+     * @param immediateFlush true or false
+     */
     public void setImmediateFlush(boolean immediateFlush) {
         this.immediateFlush = immediateFlush;
     }
-    
 }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -1,135 +1,175 @@
 /**
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
  */
 package net.logstash.logback.encoder;
-
-import static org.apache.commons.io.IOUtils.*;
-import static org.hamcrest.MatcherAssert.*;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Mockito.*;
-
-import java.io.ByteArrayOutputStream;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.commons.lang.time.FastDateFormat;
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import ch.qos.logback.core.CoreConstants;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.Map;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonReaderFactory;
+import static org.hamcrest.MatcherAssert.*;
+import org.hamcrest.Matchers;
+import static org.hamcrest.Matchers.*;
+import org.junit.Before;
+import org.junit.Test;
+import static org.mockito.Mockito.*;
 
 public class LogstashEncoderTest {
-    
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-    
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+    private static JsonReaderFactory parser = Json.createReaderFactory(null);
+    public static final int LEVEL_VALUE = 40000;
     private LogstashEncoder encoder;
     private ByteArrayOutputStream outputStream;
-    
+    private static String hostname;
+
+    static {
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            hostname = "unknown-host";
+        }
+    }
+
+    /**
+     *
+     * @throws Exception while closing the outputstream
+     */
     @Before
     public void before() throws Exception {
         outputStream = new ByteArrayOutputStream();
         encoder = new LogstashEncoder();
         encoder.init(outputStream);
     }
-    
+
+    /**
+     *
+     * @throws Exception while closing the outputstream
+     */
     @Test
     public void basicsAreIncluded() throws Exception {
         final long timestamp = System.currentTimeMillis();
-        
+
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getTimeStamp()).thenReturn(timestamp);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
-        
-        JsonNode node = MAPPER.readTree(outputStream.toByteArray());
-        
-        assertThat(node.get("@timestamp").textValue(), is(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").format(timestamp)));
-        assertThat(node.get("@fields").get("logger_name").textValue(), is("LoggerName"));
-        assertThat(node.get("@fields").get("thread_name").textValue(), is("ThreadName"));
-        assertThat(node.get("@message").textValue(), is("My message"));
-        assertThat(node.get("@fields").get("level").textValue(), is("ERROR"));
-        assertThat(node.get("@fields").get("level_value").intValue(), is(40000));
+
+        JsonObject node = createObject(outputStream.toString());
+
+        assertThat(
+                node.getString("@timestamp"),
+                is(DATE_FORMAT.format(timestamp)));
+        assertThat(node.getString("@message"), is("My message"));
+        assertThat(node.getString("@source_host"), is(hostname));
+        assertThat(node.getJsonObject("@fields").getString("logger_name"), is("LoggerName"));
+        assertThat(node.getJsonObject("@fields").getString("thread_name"), is("ThreadName"));
+        assertThat(node.getJsonObject("@fields").getString("level"), is("ERROR"));
+        assertThat(node.getJsonObject("@fields").getInt("level_value"), is(LEVEL_VALUE));
     }
-    
+
+    /**
+     *
+     * @throws Exception while closing the outputstream
+     */
     @Test
     public void closePutsSeparatorAtTheEnd() throws Exception {
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getMessage()).thenReturn("My message");
+        when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
-        
+
         encoder.doEncode(event);
         encoder.close();
         closeQuietly(outputStream);
-        
-        assertThat(outputStream.toString(), Matchers.endsWith(LINE_SEPARATOR));
+
+        assertThat(outputStream.toString(), Matchers.endsWith(CoreConstants.LINE_SEPARATOR));
     }
-    
+
+    /**
+     *
+     * @throws Exception while closing the outputstream
+     */
     @Test
     public void includingThrowableProxyIncludesStackTrace() throws Exception {
         IThrowableProxy throwableProxy = new ThrowableProxy(new Exception("My goodness"));
-        
+
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getThrowableProxy()).thenReturn(throwableProxy);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
-        
-        JsonNode node = MAPPER.readTree(outputStream.toByteArray());
-        
-        assertThat(node.get("@fields").get("stack_trace").textValue(), is(ThrowableProxyUtil.asString(throwableProxy)));
+
+        JsonObject node = createObject(outputStream.toString());
+
+        assertThat(
+                node.getJsonObject("@fields").getString("stack_trace"),
+                is(ThrowableProxyUtil.asString(throwableProxy)));
     }
-    
+
+    /**
+     *
+     * @throws Exception while closing the outputstream
+     */
     @Test
     public void propertiesInMDCAreIncluded() throws Exception {
         Map<String, String> mdcMap = new HashMap<String, String>();
         mdcMap.put("thing_one", "One");
         mdcMap.put("thing_two", "Three");
-        
+
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getMDCPropertyMap()).thenReturn(mdcMap);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
-        
-        JsonNode node = MAPPER.readTree(outputStream.toByteArray());
-        
-        assertThat(node.get("@fields").get("thing_one").textValue(), is("One"));
-        assertThat(node.get("@fields").get("thing_two").textValue(), is("Three"));
+
+        JsonObject node = createObject(outputStream.toString());
+
+        assertThat(node.getJsonObject("@fields").getString("thing_one"), is("One"));
+        assertThat(node.getJsonObject("@fields").getString("thing_two"), is("Three"));
     }
-    
+
+    /**
+     *
+     * @throws Exception while closing the outputstream
+     */
     @Test
     public void nullMDCDoesNotCauseEverythingToBlowUp() throws Exception {
         ILoggingEvent event = mock(ILoggingEvent.class);
@@ -138,9 +178,28 @@ public class LogstashEncoderTest {
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getMDCPropertyMap()).thenReturn(null);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
     }
 
+    /**
+     * Closes a stream an swallows the exception.
+     *
+     * @param closeable stream to close
+     */
+    private void closeQuietly(Closeable closeable) {
+        try {
+            if (closeable != null) {
+                closeable.close();
+            }
+        } catch (IOException ioe) {
+            // ignore
+        }
+    }
+
+    private JsonObject createObject(String input) {
+        JsonReader reader = parser.createReader(new StringReader(input));
+        return reader.readObject();
+    }
 }


### PR DESCRIPTION
JSR-353 (http://jcp.org/en/jsr/detail?id=353) has his final draft. Oracle provides an reference implementation that will be used in upcomming JEE7 specification.

I replaced net.minidev.json with the RI and removed the commons lang dependency. It will give the encoder a lower footprint.

Additional I added the hostname to source_host in the json_event.
