### PR TITLE
Add caller data

### DIFF
--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -19,64 +19,61 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang.time.FastDateFormat;
-
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.encoder.EncoderBase;
-
 import com.fasterxml.jackson.core.JsonGenerator.Feature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang.time.FastDateFormat;
 
 public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
 
-	private static final ObjectMapper MAPPER = new ObjectMapper().configure(Feature.ESCAPE_NON_ASCII, true);
+    private static final ObjectMapper MAPPER = new ObjectMapper().configure(Feature.ESCAPE_NON_ASCII, true);
     private static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
-	private static final StackTraceElement DEFAULT_CALLER_DATA = new StackTraceElement("", "", "", 0);
+    private static final StackTraceElement DEFAULT_CALLER_DATA = new StackTraceElement("", "", "", 0);
+    private boolean immediateFlush = true;
 
-	private boolean immediateFlush = true;
-    
     @Override
     public void doEncode(ILoggingEvent event) throws IOException {
-        
+
         ObjectNode eventNode = MAPPER.createObjectNode();
         eventNode.put("@timestamp", ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(event.getTimeStamp()));
         eventNode.put("@message", event.getFormattedMessage());
         eventNode.put("@fields", createFields(event));
-        
+
         write(MAPPER.writeValueAsBytes(eventNode), outputStream);
         write(CoreConstants.LINE_SEPARATOR, outputStream);
-        
+
         if (immediateFlush) {
             outputStream.flush();
         }
-        
+
     }
 
     private ObjectNode createFields(ILoggingEvent event) {
-        
+
         ObjectNode fieldsNode = MAPPER.createObjectNode();
         fieldsNode.put("logger_name", event.getLoggerName());
         fieldsNode.put("thread_name", event.getThreadName());
         fieldsNode.put("level", event.getLevel().toString());
         fieldsNode.put("level_value", event.getLevel().toInt());
 
-		StackTraceElement callerData = extractCallerData(event);
-		fieldsNode.put("caller_class_name", callerData.getClassName());
-		fieldsNode.put("caller_method_name", callerData.getMethodName());
-		fieldsNode.put("caller_file_name", callerData.getFileName());
-		fieldsNode.put("caller_line_number", callerData.getLineNumber());
+        StackTraceElement callerData = extractCallerData(event);
+        fieldsNode.put("caller_class_name", callerData.getClassName());
+        fieldsNode.put("caller_method_name", callerData.getMethodName());
+        fieldsNode.put("caller_file_name", callerData.getFileName());
+        fieldsNode.put("caller_line_number", callerData.getLineNumber());
 
-		IThrowableProxy throwableProxy = event.getThrowableProxy();
+        IThrowableProxy throwableProxy = event.getThrowableProxy();
         if (throwableProxy != null) {
             fieldsNode.put("stack_trace", ThrowableProxyUtil.asString(throwableProxy));
         }
-        
+
         Map<String, String> mdc = event.getMDCPropertyMap();
-        
+
         if (mdc != null) {
             for (Entry<String, String> entry : mdc.entrySet()) {
                 String key = entry.getKey();
@@ -84,30 +81,30 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
                 fieldsNode.put(key, value);
             }
         }
-        
+
         return fieldsNode;
-        
+
     }
 
-	private StackTraceElement extractCallerData(final ILoggingEvent event) {
-		final StackTraceElement[] ste = event.getCallerData();
-		if (ste == null || ste.length == 0) {
-			return DEFAULT_CALLER_DATA;
-		}
-		return ste[0];
-	}
+    private StackTraceElement extractCallerData(final ILoggingEvent event) {
+        final StackTraceElement[] ste = event.getCallerData();
+        if (ste == null || ste.length == 0) {
+            return DEFAULT_CALLER_DATA;
+        }
+        return ste[0];
+    }
 
-	@Override
+    @Override
     public void close() throws IOException {
         write(LINE_SEPARATOR, outputStream);
     }
-    
+
     public boolean isImmediateFlush() {
         return immediateFlush;
     }
-    
+
     public void setImmediateFlush(boolean immediateFlush) {
         this.immediateFlush = immediateFlush;
     }
-    
+
 }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -13,12 +13,10 @@
  */
 package net.logstash.logback.encoder;
 
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
-import static org.apache.commons.io.IOUtils.closeQuietly;
+import static org.apache.commons.io.IOUtils.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Collections;
@@ -38,35 +36,34 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class LogstashEncoderTest {
-    
+
     private static final ObjectMapper MAPPER = new ObjectMapper();
-    
     private LogstashEncoder encoder;
     private ByteArrayOutputStream outputStream;
-    
+
     @Before
     public void before() throws Exception {
         outputStream = new ByteArrayOutputStream();
         encoder = new LogstashEncoder();
         encoder.init(outputStream);
     }
-    
+
     @Test
     public void basicsAreIncluded() throws Exception {
         final long timestamp = System.currentTimeMillis();
-        
+
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getTimeStamp()).thenReturn(timestamp);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
-        
+
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
-        
+
         assertThat(node.get("@timestamp").textValue(), is(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").format(timestamp)));
         assertThat(node.get("@fields").get("logger_name").textValue(), is("LoggerName"));
         assertThat(node.get("@fields").get("thread_name").textValue(), is("ThreadName"));
@@ -74,7 +71,7 @@ public class LogstashEncoderTest {
         assertThat(node.get("@fields").get("level").textValue(), is("ERROR"));
         assertThat(node.get("@fields").get("level_value").intValue(), is(40000));
     }
-    
+
     @Test
     public void closePutsSeparatorAtTheEnd() throws Exception {
         ILoggingEvent event = mock(ILoggingEvent.class);
@@ -82,55 +79,55 @@ public class LogstashEncoderTest {
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
-        
+
         encoder.doEncode(event);
         encoder.close();
         closeQuietly(outputStream);
-        
+
         assertThat(outputStream.toString(), Matchers.endsWith(LINE_SEPARATOR));
     }
-    
+
     @Test
     public void includingThrowableProxyIncludesStackTrace() throws Exception {
         IThrowableProxy throwableProxy = new ThrowableProxy(new Exception("My goodness"));
-        
+
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getThrowableProxy()).thenReturn(throwableProxy);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
-        
+
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
-        
+
         assertThat(node.get("@fields").get("stack_trace").textValue(), is(ThrowableProxyUtil.asString(throwableProxy)));
     }
-    
+
     @Test
     public void propertiesInMDCAreIncluded() throws Exception {
         Map<String, String> mdcMap = new HashMap<String, String>();
         mdcMap.put("thing_one", "One");
         mdcMap.put("thing_two", "Three");
-        
+
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getLoggerName()).thenReturn("LoggerName");
         when(event.getThreadName()).thenReturn("ThreadName");
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getMDCPropertyMap()).thenReturn(mdcMap);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
-        
+
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
-        
+
         assertThat(node.get("@fields").get("thing_one").textValue(), is("One"));
         assertThat(node.get("@fields").get("thing_two").textValue(), is("Three"));
     }
-    
+
     @Test
     public void nullMDCDoesNotCauseEverythingToBlowUp() throws Exception {
         ILoggingEvent event = mock(ILoggingEvent.class);
@@ -139,30 +136,30 @@ public class LogstashEncoderTest {
         when(event.getFormattedMessage()).thenReturn("My message");
         when(event.getLevel()).thenReturn(Level.ERROR);
         when(event.getMDCPropertyMap()).thenReturn(null);
-        
+
         encoder.doEncode(event);
         closeQuietly(outputStream);
     }
 
-	@Test
-	public void callerDataIsIncluded() throws Exception {
-		ILoggingEvent event = mock(ILoggingEvent.class);
-		when(event.getLoggerName()).thenReturn("LoggerName");
-		when(event.getThreadName()).thenReturn("ThreadName");
-		when(event.getFormattedMessage()).thenReturn("My message");
-		when(event.getLevel()).thenReturn(Level.ERROR);
-		when(event.getMDCPropertyMap()).thenReturn(Collections.<String, String>emptyMap());
-		final StackTraceElement[] stackTraceElements = {new StackTraceElement("caller_class", "method_name", "file_name", 12345)};
-		when(event.getCallerData()).thenReturn(stackTraceElements);
+    @Test
+    public void callerDataIsIncluded() throws Exception {
+        ILoggingEvent event = mock(ILoggingEvent.class);
+        when(event.getLoggerName()).thenReturn("LoggerName");
+        when(event.getThreadName()).thenReturn("ThreadName");
+        when(event.getFormattedMessage()).thenReturn("My message");
+        when(event.getLevel()).thenReturn(Level.ERROR);
+        when(event.getMDCPropertyMap()).thenReturn(Collections.<String, String>emptyMap());
+        final StackTraceElement[] stackTraceElements = {new StackTraceElement("caller_class", "method_name", "file_name", 12345)};
+        when(event.getCallerData()).thenReturn(stackTraceElements);
 
-		encoder.doEncode(event);
-		closeQuietly(outputStream);
+        encoder.doEncode(event);
+        closeQuietly(outputStream);
 
-		JsonNode node = MAPPER.readTree(outputStream.toByteArray());
+        JsonNode node = MAPPER.readTree(outputStream.toByteArray());
 
-		assertThat(node.get("@fields").get("caller_class_name").textValue(), is(stackTraceElements[0].getClassName()));
-		assertThat(node.get("@fields").get("caller_method_name").textValue(), is(stackTraceElements[0].getMethodName()));
-		assertThat(node.get("@fields").get("caller_file_name").textValue(), is(stackTraceElements[0].getFileName()));
-		assertThat(node.get("@fields").get("caller_line_number").intValue(), is(stackTraceElements[0].getLineNumber()));
-	}
+        assertThat(node.get("@fields").get("caller_class_name").textValue(), is(stackTraceElements[0].getClassName()));
+        assertThat(node.get("@fields").get("caller_method_name").textValue(), is(stackTraceElements[0].getMethodName()));
+        assertThat(node.get("@fields").get("caller_file_name").textValue(), is(stackTraceElements[0].getFileName()));
+        assertThat(node.get("@fields").get("caller_line_number").intValue(), is(stackTraceElements[0].getLineNumber()));
+    }
 }


### PR DESCRIPTION
It would be useful to get the caller data stack trace information, particularly in cases where there is no exception stack trace.
