### PR TITLE
Create a shaded jar as drop-in for e.g. artifactory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,27 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                        <artifactSet>
+                            <excludes>
+                                <exclude>ch.qos.logback:*</exclude>
+                                <exclude>org.slf4j:*</exclude>
+                            </excludes>
+                        </artifactSet>
+                        <relocations>
+                            <relocation>
+                                <pattern>org.apache.commons.lang</pattern>
+                                <shadedPattern>${project.groupId}.encoder.org.apache.commons.lang</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>org.apache.commons.io</pattern>
+                                <shadedPattern>${project.groupId}.encoder.org.apache.commons.io</shadedPattern>
+                            </relocation>
+                            <relocation>
+                                <pattern>com.fasterxml.jackson</pattern>
+                                <shadedPattern>${project.groupId}.encoder.com.fasterxml.jackson</shadedPattern>
+                            </relocation>
+                        </relocations>
                         <shadedArtifactAttached>true</shadedArtifactAttached>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
This patch will create an additional shaded jar with most dependencies included. logback\* and slff4j-api are excluded as these are often already in the container classpath. I successfully included this in artifactory.war by just adding it via zip and used the following configuration:

```
<configuration>
   ...
   <appender name="STASH" class="ch.qos.logback.core.rolling.RollingFileAppender">
        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
            <level>info</level>
        </filter>
        <file>${artifactory.home}/logs/artifactory-logstash.log</file>
        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
            <FileNamePattern>${artifactory.home}/logs/artifactory-logstash.%i.log.zip</FileNamePattern>
            <MinIndex>1</MinIndex>
            <MaxIndex>9</MaxIndex>
        </rollingPolicy>
        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
            <MaxFileSize>25MB</MaxFileSize>
        </triggeringPolicy>
        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
    </appender>
    ...
    <root>
        <level value="warn"/>
        <appender-ref ref="CONSOLE"/>
        <appender-ref ref="FILE"/>
        <appender-ref ref="STASH"/>
    </root>
<configuration>
```
