### PR TITLE
Added includeCallerInfo flag to disable expensive calculation of caller information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,28 @@ Use it in your `logback.xml` like this:
 </configuration>
 ```
 
+The resulting information contains the caller info by default. 
+This can be costly to calculate and should be switched off for busy production environments.
+
+To switch if off add the includeCallerInfo property to the configuration.
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stash" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>info</level>
+        </filter>
+        <file>/some/path/to/your/file.log</file>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeCallerInfo>false</includeCallerInfo>
+        </encoder>
+    </appender>
+    <root level="all">
+        <appender-ref ref="stash" />
+    </root>
+</configuration>
+```
+
 Use it in your logstash configuration like this:
 
 ```

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -40,6 +40,12 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
     
     private boolean immediateFlush = true;
     
+    /**
+     * If true, the caller information is included in the logged data.
+     * Note: calculating the caller data is an expensive operation.
+     */
+    private boolean includeCallerInfo = true;
+    
     @Override
     public void doEncode(ILoggingEvent event) throws IOException {
         
@@ -65,11 +71,13 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
         fieldsNode.put("level", event.getLevel().toString());
         fieldsNode.put("level_value", event.getLevel().toInt());
         
-        StackTraceElement callerData = extractCallerData(event);
-        fieldsNode.put("caller_class_name", callerData.getClassName());
-        fieldsNode.put("caller_method_name", callerData.getMethodName());
-        fieldsNode.put("caller_file_name", callerData.getFileName());
-        fieldsNode.put("caller_line_number", callerData.getLineNumber());
+        if (includeCallerInfo) {
+            StackTraceElement callerData = extractCallerData(event);
+            fieldsNode.put("caller_class_name", callerData.getClassName());
+            fieldsNode.put("caller_method_name", callerData.getMethodName());
+            fieldsNode.put("caller_file_name", callerData.getFileName());
+            fieldsNode.put("caller_line_number", callerData.getLineNumber());
+        }
         
         IThrowableProxy throwableProxy = event.getThrowableProxy();
         if (throwableProxy != null) {
@@ -116,5 +124,15 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
     public void setImmediateFlush(boolean immediateFlush) {
         this.immediateFlush = immediateFlush;
     }
+
+    public boolean isIncludeCallerInfo() {
+        return includeCallerInfo;
+    }
+
+    public void setIncludeCallerInfo(boolean includeCallerInfo) {
+        this.includeCallerInfo = includeCallerInfo;
+    }
+    
+    
     
 }


### PR DESCRIPTION
Hi,

I've made the inclusion of the caller information optional as this could be a performance problem on production systems.

Cheers,
Peter
