### PR TITLE
Add logstash-access encoder

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 * Gunnar Wagenknecht (guw)
 * Brandon Zeeb (phasebash)
 * (schup)
+* James Pennell (jpennell)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use it in your `logback.xml` like this:
 </configuration>
 ```
 
-The resulting information contains the caller info by default. 
+The resulting information contains the caller info by default.
 This can be costly to calculate and should be switched off for busy production environments.
 
 To switch if off add the includeCallerInfo property to the configuration.
@@ -62,4 +62,15 @@ input {
     codec => "json"
   }
 }
+```
+
+For logback access logs, use it in your `logback-access.xml` like this:
+
+```xml
+<appender name="stash" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>/some/path/to/your/file.log</file>
+    <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder" />
+</appender>
+
+<appender-ref ref="stash" />
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,17 @@
             <version>${ch.qos.logback.version}</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
+            <version>${ch.qos.logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+            <version>2.5</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${com.fasterxml.jackson.version}</version>

--- a/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashAccessFormatter.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.Context;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.apache.commons.lang.time.FastDateFormat;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ *
+ */
+public class LogstashAccessFormatter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().configure(JsonGenerator.Feature.ESCAPE_NON_ASCII, true);
+    private static final FastDateFormat ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS = FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+
+    public byte[] writeValueAsBytes(IAccessEvent event, Context context) throws IOException {
+        return MAPPER.writeValueAsBytes(eventToNode(event, context));
+    }
+
+    public String writeValueAsString(IAccessEvent event, Context context) throws IOException {
+        return MAPPER.writeValueAsString(eventToNode(event, context));
+    }
+
+    private ObjectNode eventToNode(IAccessEvent event, Context context) {
+        ObjectNode eventNode = MAPPER.createObjectNode();
+        eventNode.put("@timestamp", ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(event.getTimeStamp()));
+        eventNode.put("@version", 1);
+        eventNode.put(
+                "@message",
+                String.format("%s - %s [%s] \"%s\" %s %s", event.getRemoteHost(), event.getRemoteUser() == null ? "-" : event.getRemoteUser(),
+                        ISO_DATETIME_TIME_ZONE_FORMAT_WITH_MILLIS.format(event.getTimeStamp()), event.getRequestURL(), event.getStatusCode(),
+                        event.getContentLength()));
+        createFields(event, context, eventNode);
+        return eventNode;
+    }
+
+    private void createFields(IAccessEvent event, Context context, ObjectNode eventNode) {
+
+        eventNode.put("@fields.method", event.getMethod());
+        eventNode.put("@fields.protocol", event.getProtocol());
+        eventNode.put("@fields.status_code", event.getStatusCode());
+        eventNode.put("@fields.requested_url", event.getRequestURL());
+        eventNode.put("@fields.requested_uri", event.getRequestURI());
+        eventNode.put("@fields.remote_host", event.getRemoteHost());
+        eventNode.put("@fields.HOSTNAME", event.getRemoteHost());
+        eventNode.put("@fields.remote_user", event.getRemoteUser());
+        eventNode.put("@fields.content_length", event.getContentLength());
+
+        if (context != null) {
+            addPropertiesAsFields(eventNode, context.getCopyOfPropertyMap());
+        }
+    }
+
+    private void addPropertiesAsFields(final ObjectNode fieldsNode, final Map<String, String> properties) {
+        if (properties != null) {
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                fieldsNode.put(key, value);
+            }
+        }
+    }
+    
+}

--- a/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashAccessEncoder.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.encoder;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.encoder.EncoderBase;
+import net.logstash.logback.LogstashAccessFormatter;
+import java.io.IOException;
+
+import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
+import static org.apache.commons.io.IOUtils.write;
+
+public class LogstashAccessEncoder extends EncoderBase<IAccessEvent> {
+    
+    private boolean immediateFlush = true;
+    
+    /**
+     * If true, the caller information is included in the logged data.
+     * Note: calculating the caller data is an expensive operation.
+     */
+    private final LogstashAccessFormatter formatter = new LogstashAccessFormatter();
+    
+    @Override
+    public void doEncode(IAccessEvent event) throws IOException {
+        
+        write(formatter.writeValueAsBytes(event, getContext()), outputStream);
+        write(CoreConstants.LINE_SEPARATOR, outputStream);
+        
+        if (immediateFlush) {
+            outputStream.flush();
+        }
+        
+    }
+    
+    @Override
+    public void close() throws IOException {
+        write(LINE_SEPARATOR, outputStream);
+    }
+    
+    public boolean isImmediateFlush() {
+        return immediateFlush;
+    }
+    
+    public void setImmediateFlush(boolean immediateFlush) {
+        this.immediateFlush = immediateFlush;
+    }
+    
+}

--- a/src/main/java/net/logstash/logback/layout/LogstashAccessLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashAccessLayout.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.layout;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.LayoutBase;
+import net.logstash.logback.LogstashAccessFormatter;
+import java.io.IOException;
+
+public class LogstashAccessLayout extends LayoutBase<IAccessEvent> {
+
+    private final LogstashAccessFormatter formatter = new LogstashAccessFormatter();
+
+    public String doLayout(IAccessEvent event) {
+        try {
+            return formatter.writeValueAsString(event, getContext());
+        } catch (IOException e) {
+            addWarn("Error formatting logging event", e);
+            return null;
+        }
+    }
+}

--- a/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashAccessEncoderTest.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.encoder;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.core.Context;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.commons.lang.time.FastDateFormat;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
+import static org.apache.commons.io.IOUtils.closeQuietly;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LogstashAccessEncoderTest {
+    
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private LogstashAccessEncoder encoder;
+    private ByteArrayOutputStream outputStream;
+    
+    @Before
+    public void before() throws Exception {
+        outputStream = new ByteArrayOutputStream();
+        encoder = new LogstashAccessEncoder();
+        encoder.init(outputStream);
+    }
+    
+    @Test
+    public void basicsAreIncluded() throws Exception {
+        final long timestamp = System.currentTimeMillis();
+        
+        IAccessEvent event = mockBasicILoggingEvent();
+        when(event.getTimeStamp()).thenReturn(timestamp);
+        
+        encoder.doEncode(event);
+        closeQuietly(outputStream);
+        
+        JsonNode node = MAPPER.readTree(outputStream.toByteArray());
+
+        assertThat(node.get("@timestamp").textValue(), is(FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").format
+                (timestamp)));
+        assertThat(node.get("@version").intValue(), is(1));
+        assertThat(node.get("@message").textValue(), is(String.format("%s - %s [%s] \"%s\" %s %s", event.getRemoteHost(), event.getRemoteUser(),
+                FastDateFormat.getInstance("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").format
+                (event.getTimeStamp()), event.getRequestURL(), event.getStatusCode(),
+                event.getContentLength())));
+        
+        assertThat(node.get("@fields.method").textValue(), is(event.getMethod()));
+        assertThat(node.get("@fields.protocol").textValue(), is(event.getProtocol()));
+        assertThat(node.get("@fields.status_code").asInt(), is(event.getStatusCode()));
+        assertThat(node.get("@fields.requested_url").textValue(), is(event.getRequestURL()));
+        assertThat(node.get("@fields.requested_uri").textValue(), is(event.getRequestURI()));
+        assertThat(node.get("@fields.remote_host").textValue(), is(event.getRemoteHost()));
+        assertThat(node.get("@fields.HOSTNAME").textValue(), is(event.getRemoteHost()));
+        assertThat(node.get("@fields.remote_user").textValue(), is(event.getRemoteUser()));
+        assertThat(node.get("@fields.content_length").asLong(), is(event.getContentLength()));
+        
+    }
+    
+    @Test
+    public void closePutsSeparatorAtTheEnd() throws Exception {
+        IAccessEvent event = mockBasicILoggingEvent();
+        
+        encoder.doEncode(event);
+        encoder.close();
+        closeQuietly(outputStream);
+        
+        assertThat(outputStream.toString(), Matchers.endsWith(LINE_SEPARATOR));
+    }
+    
+    @Test
+    public void propertiesInContextAreIncluded() throws Exception {
+        Map<String, String> propertyMap = new HashMap<String, String>();
+        propertyMap.put("thing_one", "One");
+        propertyMap.put("thing_two", "Three");
+        
+        final Context context = mock(Context.class);
+        when(context.getCopyOfPropertyMap()).thenReturn(propertyMap);
+        
+        IAccessEvent event = mockBasicILoggingEvent();
+        
+        encoder.setContext(context);
+        encoder.doEncode(event);
+        closeQuietly(outputStream);
+        
+        JsonNode node = MAPPER.readTree(outputStream.toByteArray());
+        
+        assertThat(node.get("thing_one").textValue(), is("One"));
+        assertThat(node.get("thing_two").textValue(), is("Three"));
+    }
+    
+    @Test
+    public void immediateFlushIsSane() {
+        encoder.setImmediateFlush(true);
+        assertThat(encoder.isImmediateFlush(), is(true));
+        
+        encoder.setImmediateFlush(false);
+        assertThat(encoder.isImmediateFlush(), is(false));
+    }
+    
+    private IAccessEvent mockBasicILoggingEvent() {
+        IAccessEvent event = mock(IAccessEvent.class);
+        when(event.getContentLength()).thenReturn(123L);
+        when(event.getMethod()).thenReturn("GET");
+        when(event.getProtocol()).thenReturn("HTTPS");
+        when(event.getRemoteHost()).thenReturn("123.123.123.123");
+        when(event.getRemoteUser()).thenReturn("remote-user");
+        when(event.getRequestURI()).thenReturn("/my/uri");
+        when(event.getRequestURL()).thenReturn("https://123.123.123.123/my/uri");
+        when(event.getStatusCode()).thenReturn(200);
+        when(event.getTimeStamp()).thenReturn(System.currentTimeMillis());
+        return event;
+    }
+    
+}


### PR DESCRIPTION
Encoder, Formatter, and Layout for [logback-access](http://logback.qos.ch/access.html) logs in the same format as regular logs using LogstashEncoder. This pull request also includes test for the encoder.

This feature was mentioned/requested in issue #9.
