### PR TITLE
shaded jars should be removed from <dependencies>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.0</version>
+                    <version>2.2</version>
                     <executions>
                         <execution>
                             <goals>
@@ -269,7 +269,6 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                         <artifactSet>
                             <excludes>
                                 <exclude>ch.qos.logback:*</exclude>
@@ -290,7 +289,6 @@
                                 <shadedPattern>${project.groupId}.encoder.com.fasterxml.jackson</shadedPattern>
                             </relocation>
                         </relocations>
-                        <shadedArtifactAttached>true</shadedArtifactAttached>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
- updated shade plugin version (got strange exception during clean install with maven 3.1.1) 
- removed promoteTransitiveDependencies=true because the whole point of shading is to reduce dependencies (and there are no transitive dependencies that we're not shading)
- removed shadedArtifactAttached=true, this one seems to cause the shade plugin not to remove the shaded dependencies

Overall i think this results in a more correct release. The way it is now is not wrong but one does not expect shaded jars to be still dependencies, it's the whole point of shading after all.
