### PR TITLE
Added test case for logback configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 
 .idea
 *.iml
+test.log

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -86,8 +86,8 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
         }
     }
     
-    public JsonNode getCustomFields() {
-        return formatter.getCustomFields();
+    public String getCustomFields() {
+        return formatter.getCustomFields().toString();
     }
     
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="true">
+    <appender name="stash" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>info</level>
+        </filter>
+        <file>${java.io.tmpdir}/test.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${java.io.tmpdir}/test.log.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>1</maxHistory>
+        </rollingPolicy>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"appname":"damnGodWebservice","roles":["customerorder", "auth"], "buildinfo": { "version" : "Version 0.1.0-SNAPSHOT", "lastcommit" : "75473700d5befa953c45f630c6d9105413c16fe1"} }</customFields>
+        </encoder>
+    </appender>
+    <logger name="net.logstash.logback.encoder.LogstashEncoderTest" level="DEBUG">
+        <appender-ref ref="stash" />
+    </logger>
+</configuration>


### PR DESCRIPTION
Hello,

The current state on master does not allow the use of a logback.xml file for the configuration, as the following error is emitted on the console during a run with a logback.xml that has the debug flag set:

```
18:27:39,129 |-ERROR in ch.qos.logback.core.joran.spi.Interpreter@13:27 - no applicable action for [customFields], current pattern is [[configuration][appender][encoder][customFields]]
```

This was due to the getter getCustomFields() returning a JsonNode object instead of a String object. As such the JoranConfigurator could not inject the customFields.

To test my claims you can change the getter back to the previous implementation and run the tests. You will see that the new test using the logback-test.xml file will fail.

For temporary storage of the log file I used the temporary directory as set in the system variable "java.io.tmpdir".

Cheers,

Matjaž
