### PR TITLE
logback dependencies should be optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,16 +65,19 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
             <version>${ch.qos.logback.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${ch.qos.logback.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-access</artifactId>
             <version>${ch.qos.logback.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
This patch makes the actual logback dependencies optional, so that ppl can choose whatever version they want without having to first exclude these dependencies. This will also keep https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html happy, a must-have rule on any good sized project. 
