### PR TITLE
add 'rollingPolicy' in config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Use it in your `logback.xml` like this:
             <level>info</level>
         </filter>
         <file>/some/path/to/your/file.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/some/path/to/your/file.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
     <root level="all">
@@ -42,6 +46,10 @@ To switch it on add the includeCallerInfo property to the configuration.
             <level>info</level>
         </filter>
         <file>/some/path/to/your/file.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/some/path/to/your/file.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>        
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <includeCallerInfo>true</includeCallerInfo>
         </encoder>
@@ -61,6 +69,10 @@ Add custom json fields to your json events like this :
             <level>info</level>
         </filter>
         <file>/some/path/to/your/file.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>/some/path/to/your/file.log.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>{"appname":"damnGodWebservice","roles":["customerorder","auth"],"buildinfo":{"version":"Version 0.1.0-SNAPSHOT","lastcommit":"75473700d5befa953c45f630c6d9105413c16fe1"}}</customFields>
         </encoder>


### PR DESCRIPTION
According to logback [docs](http://logback.qos.ch/manual/appenders.html#RollingFileAppender) `RollingFileAppender` should be configured with `RollingPolicy` and `TriggeringPolicy`, otherwise it won't work.
`TimeBasedRollingPolicy` implements both interfaces, so I've added it to configuration examples.
