### PR TITLE
Add support for customFields and includeCallerInfo to LogstashSocketAppender

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,3 +14,4 @@
 * Matjaž (mpecan)
 * (schup)
 * Ryan O'Keeffe (danielredoak)
+* Phil Clay (philsttr)

--- a/src/main/java/net/logstash/logback/appender/LogstashSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashSocketAppender.java
@@ -19,10 +19,17 @@ import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.net.SyslogAppenderBase;
 
 public class LogstashSocketAppender extends SyslogAppenderBase<ILoggingEvent> {
+	
+    private String customFields;
+    private boolean includeCallerInfo;
     
     @Override
     public Layout<ILoggingEvent> buildLayout() {
-        return new LogstashLayout();
+        LogstashLayout layout = new LogstashLayout();
+        layout.setContext(getContext());
+        layout.setCustomFields(customFields);
+        layout.setIncludeCallerInfo(includeCallerInfo);
+        return layout;
     }
     
     public LogstashSocketAppender() {
@@ -45,5 +52,21 @@ public class LogstashSocketAppender extends SyslogAppenderBase<ILoggingEvent> {
      */
     public void setHost(String host) {
         setSyslogHost(host);
+    }
+    
+    public void setCustomFields(String customFields) {
+        this.customFields = customFields;
+    }
+    
+    public String getCustomFields() {
+        return this.customFields;
+    }
+    
+    public boolean isIncludeCallerInfo() {
+        return this.includeCallerInfo;
+    }
+    
+    public void setIncludeCallerInfo(boolean includeCallerInfo) {
+        this.includeCallerInfo = includeCallerInfo;
     }
 }

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -13,7 +13,8 @@
  */
 package net.logstash.logback.encoder;
 
-import static org.apache.commons.io.IOUtils.*;
+import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
+import static org.apache.commons.io.IOUtils.write;
 
 import java.io.IOException;
 
@@ -22,19 +23,10 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.encoder.EncoderBase;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
     
     private boolean immediateFlush = true;
     
-    /**
-     * If true, the caller information is included in the logged data.
-     * Note: calculating the caller data is an expensive operation.
-     */
     private final LogstashFormatter formatter = new LogstashFormatter();
     
     @Override
@@ -54,10 +46,6 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
         write(LINE_SEPARATOR, outputStream);
     }
     
-    public static JsonNode parseCustomFields(String customFields) throws JsonParseException, JsonProcessingException, IOException {
-        return new ObjectMapper().getFactory().createParser(customFields).readValueAsTree();
-    }
-    
     public boolean isImmediateFlush() {
         return immediateFlush;
     }
@@ -75,15 +63,7 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
     }
     
     public void setCustomFields(String customFields) {
-        try {
-            formatter.setCustomFields(parseCustomFields(customFields));
-        } catch (JsonParseException e) {
-            addError("Failed to parse custom fields [" + customFields + "]", e);
-        } catch (JsonProcessingException e) {
-            addError("Failed to parse custom fields [" + customFields + "]", e);
-        } catch (IOException e) {
-            addError("Failed to parse custom fields [" + customFields + "]", e);
-        }
+        formatter.setCustomFieldsFromString(customFields, this);
     }
     
     public String getCustomFields() {

--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -31,4 +31,20 @@ public class LogstashLayout extends LayoutBase<ILoggingEvent> {
             return null;
         }
     }
+    
+    public void setCustomFields(String customFields) {
+        formatter.setCustomFieldsFromString(customFields, this);
+    }
+
+    public String getCustomFields() {
+        return formatter.getCustomFields().toString();
+    }
+    
+    public boolean isIncludeCallerInfo() {
+        return formatter.isIncludeCallerInfo();
+    }
+
+    public void setIncludeCallerInfo(boolean includeCallerInfo) {
+        formatter.setIncludeCallerInfo(includeCallerInfo);
+    }
 }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -27,6 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.logstash.logback.LogstashFormatter;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.time.FastDateFormat;
 import org.hamcrest.Matchers;
@@ -280,8 +282,8 @@ public class LogstashEncoderTest {
         JsonNode node = MAPPER.readTree(outputStream.toByteArray());
         
         assertThat(node.get("appname").textValue(), is("damnGodWebservice"));
-        Assert.assertTrue(node.get("roles").equals(LogstashEncoder.parseCustomFields("[\"customerorder\", \"auth\"]")));
-        Assert.assertTrue(node.get("buildinfo").equals(LogstashEncoder.parseCustomFields("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
+        Assert.assertTrue(node.get("roles").equals(LogstashFormatter.parseCustomFields("[\"customerorder\", \"auth\"]")));
+        Assert.assertTrue(node.get("buildinfo").equals(LogstashFormatter.parseCustomFields("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
     }
     
     @Test
@@ -297,8 +299,8 @@ public class LogstashEncoderTest {
         JsonNode node = MAPPER.readTree(lines.get(0).getBytes("UTF-8"));
         
         assertThat(node.get("appname").textValue(), is("damnGodWebservice"));
-        Assert.assertTrue(node.get("roles").equals(LogstashEncoder.parseCustomFields("[\"customerorder\", \"auth\"]")));
-        Assert.assertTrue(node.get("buildinfo").equals(LogstashEncoder.parseCustomFields("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
+        Assert.assertTrue(node.get("roles").equals(LogstashFormatter.parseCustomFields("[\"customerorder\", \"auth\"]")));
+        Assert.assertTrue(node.get("buildinfo").equals(LogstashFormatter.parseCustomFields("{ \"version\" : \"Version 0.1.0-SNAPSHOT\", \"lastcommit\" : \"75473700d5befa953c45f630c6d9105413c16fe1\"}")));
     }
     
     private void assertJsonArray(JsonNode jsonNode, String... expected) {


### PR DESCRIPTION
Add support for customFields and includeCallerInfo to LogstashSocketAppender.
(previously these were only supported when using LogstashEncoder.)

Also ensure context is set on the LogstashLayout when using the LogstashSocketAppender.
