### PR TITLE
Fixed NPE when using logstash appender without any custom fields.

### DIFF
--- a/src/main/java/net/logstash/logback/appender/LogstashSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashSocketAppender.java
@@ -20,7 +20,7 @@ import ch.qos.logback.core.net.SyslogAppenderBase;
 
 public class LogstashSocketAppender extends SyslogAppenderBase<ILoggingEvent> {
 	
-    private String customFields;
+    private String customFields = "{}";
     private boolean includeCallerInfo;
     
     @Override

--- a/src/test/java/net/logstash/logback/appender/LogstashSocketAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/LogstashSocketAppenderTest.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.appender;
+
+import org.junit.Test;
+
+public class LogstashSocketAppenderTest {
+
+    @Test
+    public void testNoNullPointerWithNoCustomFields() throws Exception {
+        //The JSON Parser has been throwing a NPE if no custom field value is specified
+        LogstashSocketAppender appender = new LogstashSocketAppender();
+        appender.setHost("foo.com");
+        appender.buildLayout();
+    }
+
+    @Test
+    public void testNoNullPointerWithCustomFields() throws Exception {
+        LogstashSocketAppender appender = new LogstashSocketAppender();
+        appender.setHost("foo.com");
+        appender.setCustomFields("");
+        appender.buildLayout();
+    }
+}


### PR DESCRIPTION
We were getting the following NPE exception when using a logstash syslog appender without any customFields:
RuntimeException in Action for tag [appender] java.lang.NullPointerException
    at java.lang.NullPointerException
    at  at java.io.StringReader.<init>(StringReader.java:50)
    at  at net.logstash.logback.encoder.com.fasterxml.jackson.core.JsonFactory.createParser(JsonFactory.java:835)
    at  at net.logstash.logback.LogstashFormatter.parseCustomFields(LogstashFormatter.java:188)
    at  at net.logstash.logback.LogstashFormatter.setCustomFieldsFromString(LogstashFormatter.java:193)
    at  at net.logstash.logback.layout.LogstashLayout.setCustomFields(LogstashLayout.java:36)
    at  at net.logstash.logback.appender.LogstashSocketAppender.buildLayout(LogstashSocketAppender.java:30)
    at  at ch.qos.logback.core.net.SyslogAppenderBase.start(SyslogAppenderBase.java:64)
    at  at ch.qos.logback.core.joran.action.AppenderAction.end(AppenderAction.java:96)
    at  at ch.qos.logback.core.joran.spi.Interpreter.callEndAction(Interpreter.java:317)
    at  at ch.qos.logback.core.joran.spi.Interpreter.endElement(Interpreter.java:196)
    at  at ch.qos.logback.core.joran.spi.Interpreter.endElement(Interpreter.java:182)
    at  at ch.qos.logback.core.joran.spi.EventPlayer.play(EventPlayer.java:62)
    at  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:149)
    at  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:135)
    at  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java:99)
    at  at ch.qos.logback.core.joran.GenericConfigurator.doConfigure(GenericConfigurator.java
...

I've added a default JSON array to stop the parser complaining. Please see included test cases.
