### PR TITLE
compatible to logback 1.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ch.qos.logback.version>1.1.1</ch.qos.logback.version>
+        <ch.qos.logback.version>1.1.2</ch.qos.logback.version>
         <com.fasterxml.jackson.version>2.3.2</com.fasterxml.jackson.version>
         <commons.io.version>2.4</commons.io.version>
         <commons.lang.version>2.6</commons.lang.version>

--- a/src/main/java/net/logstash/logback/appender/LogstashSocketAppender.java
+++ b/src/main/java/net/logstash/logback/appender/LogstashSocketAppender.java
@@ -13,10 +13,14 @@
  */
 package net.logstash.logback.appender;
 
+import java.net.SocketException;
+import java.net.UnknownHostException;
+
 import net.logstash.logback.layout.LogstashLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.net.SyslogAppenderBase;
+import ch.qos.logback.core.net.SyslogOutputStream;
 
 public class LogstashSocketAppender extends SyslogAppenderBase<ILoggingEvent> {
 	
@@ -69,4 +73,9 @@ public class LogstashSocketAppender extends SyslogAppenderBase<ILoggingEvent> {
     public void setIncludeCallerInfo(boolean includeCallerInfo) {
         this.includeCallerInfo = includeCallerInfo;
     }
+
+	@Override
+	public SyslogOutputStream createOutputStream() throws UnknownHostException, SocketException {
+		return new SyslogOutputStream(this.getHost(), this.getPort());
+	}
 }


### PR DESCRIPTION
This change will enable the encoder for logback 1.1.2. 
Not compatible to lower logback versions.
