### PR TITLE
Enhancement: Add support for custom context maps so that JSON fields can be passed directly from log calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,37 @@ Results in the following in the Logstash JSON
     }
 ```
 
+### Custom Context Fields
+For some situations you might want to directly pass fields to the JSON message so it doesn't need to be parsed from the message.
+If this feature is enabled and the last argument in the argument list is a `Map` then it will be added to the JSON.
+
+Configuration:
+```xml
+    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <enableContextMap>true</enableContextMap>
+    </encoder>
+```
+
+Example:
+```java
+    log.info("Service started in {} seconds", duration/1000, Collections.singletonMap("duration", duration));
+```
+
+Result:
+```json
+{
+  "@timestamp": "2014-06-04T15:26:14.464+02:00",
+  "@version": 1,
+  "message": "Service started in 12 seconds",
+  "logger_name": "com.acme.Tester",
+  "thread_name": "main",
+  "level": "INFO",
+  "level_value": 20000,
+  "duration": 12368,
+  "tags": []
+}
+```
+
 ### Logback access logs
 For logback access logs, use it in your `logback-access.xml` like this:
 

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -69,5 +69,29 @@ public class LogstashEncoder extends EncoderBase<ILoggingEvent> {
     public String getCustomFields() {
         return formatter.getCustomFields().toString();
     }
-    
+
+    /**
+     * <p>If set to true the encoder will search logging event array and if the last item is a Map, entries will
+     * be included in the message.
+     * </p>
+     * <p>
+     * Example:
+     * <pre>
+     *     log.info("Service started in {} seconds", duration/1000, Collections.singletonMap("duration", duration))
+     * </pre>
+     * Will produce:
+     * <pre>
+     * {
+     *     "@timestamp": "2014-06-04T15:26:14.464+02:00",
+     *     "message": "Service started in 8 seconds",
+     *     "level": "INFO",
+     *     "duration": 8496
+     *     ...
+     * </pre>
+     * </p>
+     * @param enableContextMap <code>true</code> to enable context map
+     */
+    public void setEnableContextMap(boolean enableContextMap) { formatter.setEnableContextMap(enableContextMap); }
+
+    public boolean isEnableContextMap() { return formatter.isEnableContextMap(); }
 }


### PR DESCRIPTION
We found the JSON marker not ideal for our use cases where you would like to pass ad-hoc entries (e.g. metrics) directly as a field to the JSON object.

This proposal makes it possible by looking at the last argument in the argument list. If the argument is a `Map` then it will be added to the JSON.

Example:

``` java
log.info("Service started in {} seconds", duration/1000, Collections.singletonMap("duration", duration));
```

Will produce:

``` json
 {
   "@timestamp": "2014-06-04T15:26:14.464+02:00",
   "@version": 1,
   "message": "Service started in 12 seconds",
   "logger_name": "com.acme.Tester",
   "thread_name": "main",
   "level": "INFO",
   "level_value": 20000,
   "duration": 12368,
   "tags": []
 }
```

The good thing is that the placeholders in the message can have a human readable version of the data, whereas the "raw" context entries are good for processing.

This feature is disabled by default and needs to be enabled:

``` xml
    <encoder class="net.logstash.logback.encoder.LogstashEncoder">
        <enableContextMap>true</enableContextMap>
    </encoder>
```
