### PR TITLE
LogstashLayout: enabling contextmap to the underlying formatter

### DIFF
--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -47,4 +47,8 @@ public class LogstashLayout extends LayoutBase<ILoggingEvent> {
     public void setIncludeCallerInfo(boolean includeCallerInfo) {
         formatter.setIncludeCallerInfo(includeCallerInfo);
     }
+    
+    public void setEnableContextMap(boolean enableContextMap) {
+        formatter.setEnableContextMap(enableContextMap);
+    }
 }


### PR DESCRIPTION
had that patch in place before the upgrade of 3.0. would be nice for backward compatibility.
