### PR TITLE
FastISOTimestampFormatter as a fast alternative to Java's DateTimeFormatter for standard ISO formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1643,8 +1643,16 @@ The value of the `timestampPattern` can be any of the following:
 * `[` _`constant`_ `]` - (e.g. `[ISO_OFFSET_DATE_TIME]`) timestamp written using the given `DateTimeFormatter` constant
 * any other value - (e.g. `yyyy-MM-dd'T'HH:mm:ss.SSS`) timestamp written using a `DateTimeFormatter` created from the given pattern
 
+The provider uses a standard Java DateTimeFormatter under the hood. However, special optimisations are applied when using one of  the following standard ISO formats that make it nearly 7x faster:
 
-You can change the timezone like this:
+* `[ISO_OFFSET_DATE_TIME]`
+* `[ISO_ZONED_DATE_TIME`]
+* `[ISO_LOCAL_DATE_TIME`]
+* `[ISO_DATE_TIME`]
+* `[ISO_INSTANT`]
+
+
+The formatter uses the default TimeZone of the host Java platform by default. You can change it like this:
 
 ```xml
 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -1655,6 +1663,7 @@ You can change the timezone like this:
 The value of the `timeZone` element can be any string accepted by java's `TimeZone.getTimeZone(String id)` method.
 For example `America/Los_Angeles`, `GMT+10` or `UTC`.
 Use the special value `[DEFAULT]` to use the default TimeZone of the system.
+
 
 
 ## Customizing LoggingEvent Message

--- a/src/main/java/net/logstash/logback/composite/AbstractFormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractFormattedTimestampJsonProvider.java
@@ -191,7 +191,7 @@ public abstract class AbstractFormattedTimestampJsonProvider<Event extends Defer
             //
             String constant = pattern.substring(1, pattern.length() - 1);
 
-            // Use our fast ISOTimestampFormatter if suitable...
+            // Use our fast FastISOTimestampFormatter if suitable...
             //
             ZoneId zone = timeZone.toZoneId();
             if ("ISO_OFFSET_DATE_TIME".equals(constant)) {

--- a/src/main/java/net/logstash/logback/composite/AbstractFormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractFormattedTimestampJsonProvider.java
@@ -19,8 +19,11 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
 import net.logstash.logback.util.TimeZoneUtils;
@@ -86,43 +89,21 @@ public abstract class AbstractFormattedTimestampJsonProvider<Event extends Defer
      * Writes the timestamp to the JsonGenerator.
      */
     private TimestampWriter timestampWriter;
-
+    
     /**
      * Writes the timestamp to the JsonGenerator
      */
-    private interface TimestampWriter {
+    protected interface TimestampWriter {
         void writeTo(JsonGenerator generator, String fieldName, long timestampInMillis) throws IOException;
 
         String getTimestampAsString(long timestampInMillis);
     }
 
-    /**
-     * Writes the timestamp to the JsonGenerator as a string formatted by the pattern.
-     */
-    private static class PatternTimestampWriter implements TimestampWriter {
-
-        private final DateTimeFormatter formatter;
-
-        PatternTimestampWriter(DateTimeFormatter formatter) {
-            this.formatter = formatter;
-        }
-
-
-        @Override
-        public void writeTo(JsonGenerator generator, String fieldName, long timestampInMillis) throws IOException {
-            JsonWritingUtils.writeStringField(generator, fieldName, getTimestampAsString(timestampInMillis));
-        }
-
-        @Override
-        public String getTimestampAsString(long timestampInMillis) {
-            return formatter.format(Instant.ofEpochMilli(timestampInMillis));
-        }
-    }
 
     /**
      * Writes the timestamp to the JsonGenerator as a number of milliseconds since unix epoch.
      */
-    private static class NumberTimestampWriter implements TimestampWriter {
+    protected static class NumberTimestampWriter implements TimestampWriter {
 
         @Override
         public void writeTo(JsonGenerator generator, String fieldName, long timestampInMillis) throws IOException {
@@ -136,10 +117,16 @@ public abstract class AbstractFormattedTimestampJsonProvider<Event extends Defer
     }
 
     /**
-     * Writes the timestamp to the JsonGenerator as a string representation of the of milliseconds since unix epoch.
+     * Writes the timestamp to the JsonGenerator as a string, converting the timestamp millis into a
+     * String using the supplied Function.
      */
-    private static class StringTimestampWriter implements TimestampWriter {
-
+    protected static class StringFormatterWriter implements TimestampWriter {
+        private final Function<Long, String> provider;
+        
+        StringFormatterWriter(Function<Long, String> provider) {
+            this.provider = Objects.requireNonNull(provider);
+        }
+        
         @Override
         public void writeTo(JsonGenerator generator, String fieldName, long timestampInMillis) throws IOException {
             JsonWritingUtils.writeStringField(generator, fieldName, getTimestampAsString(timestampInMillis));
@@ -147,11 +134,21 @@ public abstract class AbstractFormattedTimestampJsonProvider<Event extends Defer
 
         @Override
         public String getTimestampAsString(long timestampInMillis) {
-            return Long.toString(timestampInMillis);
+            return provider.apply(timestampInMillis);
         }
-
+        
+        static StringFormatterWriter with(DateTimeFormatter formatter) {
+            return new StringFormatterWriter(tstamp -> formatter.format(Instant.ofEpochMilli(tstamp)));
+        }
+        static StringFormatterWriter with(FastISOTimestampFormatter formatter) {
+            return new StringFormatterWriter(formatter::format);
+        }
+        static StringFormatterWriter with(Function<Long, String> formatter) {
+            return new StringFormatterWriter(formatter);
+        }
     }
-
+    
+    
     public AbstractFormattedTimestampJsonProvider() {
         setFieldName(FIELD_TIMESTAMP);
         updateTimestampWriter();
@@ -177,34 +174,78 @@ public abstract class AbstractFormattedTimestampJsonProvider<Event extends Defer
      * Updates the {@link #timestampWriter} value based on the current pattern and timeZone.
      */
     private void updateTimestampWriter() {
+        timestampWriter = createTimestampWriter();
+    }
+    
+    private TimestampWriter createTimestampWriter() {
         if (UNIX_TIMESTAMP_AS_NUMBER.equals(pattern)) {
-            timestampWriter = new NumberTimestampWriter();
-        } else if (UNIX_TIMESTAMP_AS_STRING.equals(pattern)) {
-            timestampWriter = new StringTimestampWriter();
-        } else if (pattern.startsWith("[") && pattern.endsWith("]")) {
-            String constant = pattern.substring("[".length(), pattern.length() - "]".length());
-            try {
-                Field field = DateTimeFormatter.class.getField(constant);
-                if (Modifier.isStatic(field.getModifiers())
-                        && Modifier.isFinal(field.getModifiers())
-                        && field.getType().equals(DateTimeFormatter.class)) {
-                    try {
-                        DateTimeFormatter formatter = (DateTimeFormatter) field.get(null);
-                        timestampWriter = new PatternTimestampWriter(formatter.withZone(timeZone.toZoneId()));
-                    } catch (IllegalAccessException e) {
-                        throw new IllegalArgumentException(String.format("Unable to get value of constant named %s in %s", constant, DateTimeFormatter.class), e);
-                    }
-                } else {
-                    throw new IllegalArgumentException(String.format("Field named %s in %s is not a constant %s", constant, DateTimeFormatter.class, DateTimeFormatter.class));
-                }
-            } catch (NoSuchFieldException e) {
-                throw new IllegalArgumentException(String.format("No constant named %s found in %s", constant, DateTimeFormatter.class), e);
+            return new NumberTimestampWriter();
+        }
+        
+        if (UNIX_TIMESTAMP_AS_STRING.equals(pattern)) {
+            return StringFormatterWriter.with(tstamp -> Long.toString(tstamp));
+        }
+        
+        if (pattern.startsWith("[") && pattern.endsWith("]")) {
+            // Get the standard formatter by name...
+            //
+            String constant = pattern.substring(1, pattern.length() - 1);
+
+            // Use our fast ISOTimestampFormatter if suitable...
+            //
+            ZoneId zone = timeZone.toZoneId();
+            if ("ISO_OFFSET_DATE_TIME".equals(constant)) {
+                return StringFormatterWriter.with(FastISOTimestampFormatter.isoOffsetDateTime(zone));
             }
-        } else {
-            timestampWriter = new PatternTimestampWriter(DateTimeFormatter.ofPattern(pattern).withZone(timeZone.toZoneId()));
+            if ("ISO_ZONED_DATE_TIME".equals(constant)) {
+                return StringFormatterWriter.with(FastISOTimestampFormatter.isoZonedDateTime(zone));
+            }
+            if ("ISO_LOCAL_DATE_TIME".equals(constant)) {
+                return StringFormatterWriter.with(FastISOTimestampFormatter.isoLocalDateTime(zone));
+            }
+            if ("ISO_DATE_TIME".equals(constant)) {
+                return StringFormatterWriter.with(FastISOTimestampFormatter.isoDateTime(zone));
+            }
+            if ("ISO_INSTANT".equals(constant)) {
+                return StringFormatterWriter.with(FastISOTimestampFormatter.isoInstant(zone));
+            }
+
+            
+            // Otherwise try one of the default formatters...
+            //
+            DateTimeFormatter formatter = getStandardDateTimeFormatter(constant).withZone(zone);
+            return StringFormatterWriter.with(formatter);
+        }
+        
+        
+        // Construct using a pattern
+        //
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern).withZone(timeZone.toZoneId());
+        return StringFormatterWriter.with(formatter);
+    }
+    
+    
+    private DateTimeFormatter getStandardDateTimeFormatter(String name) {
+        try {
+            Field field = DateTimeFormatter.class.getField(name);
+            if (Modifier.isStatic(field.getModifiers())
+                    && Modifier.isFinal(field.getModifiers())
+                    && field.getType().equals(DateTimeFormatter.class)) {
+                    return (DateTimeFormatter) field.get(null);
+            }
+            else {
+                throw new IllegalArgumentException(String.format("Field named %s in %s is not a constant %s", name, DateTimeFormatter.class, DateTimeFormatter.class));
+            }
+        }
+        catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(String.format("Unable to get value of constant named %s in %s", name, DateTimeFormatter.class), e);
+        }
+        catch (NoSuchFieldException e) {
+            throw new IllegalArgumentException(String.format("No constant named %s found in %s", name, DateTimeFormatter.class), e);
         }
     }
-
+    
+    
     public String getPattern() {
         return pattern;
     }

--- a/src/main/java/net/logstash/logback/composite/FastISOTimestampFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/FastISOTimestampFormatter.java
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.zone.ZoneOffsetTransition;
+
+/**
+ * A fast alternative to DateTimeFormatter when formatting millis using an ISO format.
+ * 
+ * <p>This class is thread safe.
+ * 
+ * <p>Note: This class is for internal use only and subject to backward incompatible change
+ * at any time.
+ * 
+ * @author brenuart
+ */
+class FastISOTimestampFormatter {
+    /**
+     * ThreadLocal with reusable {@link StringBuilder} instances
+     */
+    private static ThreadLocal<StringBuilder> STRING_BUILDERS = ThreadLocal.withInitial(StringBuilder::new);
+
+    /**
+     * The actual DateTimeFormatter used to format the timestamp when the cached
+     * value cannot be used
+     */
+    private final DateTimeFormatter formatter;
+    
+    /**
+     * Holds the cached formatted value. Can be reused only when the timestamp to format
+     * is in the same ZoneOffset as the cached value.
+     * 
+     * This class is immutable and a new instance is created when needed. Two concurrent threads may create two
+     * identical instances but only one will eventually remain. This strategy is cheaper than a lock or a volatile
+     * field.
+     */
+    private ZoneOffsetState zoneOffsetState;
+    
+    /**
+     * Whether trailing zero should be trimmed from the millis part
+     */
+    private boolean trimMillis = true;
+    
+    
+    /* Visible for testing */
+    FastISOTimestampFormatter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+        this.zoneOffsetState = new ZoneOffsetState(System.currentTimeMillis());
+    }
+    
+    
+    /* Visible for testing */
+    private void setTrimMillis(boolean trimMillis) {
+        this.trimMillis = trimMillis;
+    }
+    
+    
+    /**
+     * Format the {@code timestamp} millis.
+     * 
+     * @param timestamp the millis to format
+     * @return the formatted result
+     */
+    public String format(long timestamp) {
+        ZoneOffsetState current = this.zoneOffsetState;
+        
+        if (!current.isApplicable(timestamp)) {
+            current = new ZoneOffsetState(timestamp);
+            this.zoneOffsetState = current;
+        }
+
+        return current.format(timestamp);
+    }
+
+    
+    /**
+     * Create a fast formatter using the same format as {@link DateTimeFormatter#ISO_OFFSET_DATE_TIME}.
+     * 
+     * @param zoneId the zone override
+     * @return a fast formatter
+     */
+    public static FastISOTimestampFormatter isoOffsetDateTime(ZoneId zoneId) {
+        return new FastISOTimestampFormatter(DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zoneId));
+    }
+
+    /**
+     * Create a fast formatter using the same format as {@link DateTimeFormatter#ISO_ZONED_DATE_TIME}.
+     * 
+     * @param zoneId the zone override
+     * @return a fast formatter
+     */
+    public static FastISOTimestampFormatter isoZonedDateTime(ZoneId zoneId) {
+        return new FastISOTimestampFormatter(DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(zoneId));
+    }
+    
+    /**
+     * Create a fast formatter using the same format as {@link DateTimeFormatter#ISO_LOCAL_DATE_TIME}.
+     * 
+     * @param zoneId the zone override
+     * @return a fast formatter
+     */
+    public static FastISOTimestampFormatter isoLocalDateTime(ZoneId zoneId) {
+        return new FastISOTimestampFormatter(DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(zoneId));
+    }
+    
+    /**
+     * Create a fast formatter using the same format as {@link DateTimeFormatter#ISO_DATE_TIME}.
+     * 
+     * @param zoneId the zone override
+     * @return a fast formatter
+     */
+    public static FastISOTimestampFormatter isoDateTime(ZoneId zoneId) {
+        return new FastISOTimestampFormatter(DateTimeFormatter.ISO_DATE_TIME.withZone(zoneId));
+    }
+    
+    /**
+     * Create a fast formatter using the same format as {@link DateTimeFormatter#ISO_INSTANT}.
+     * 
+     * @param zoneId the zone override
+     * @return a fast formatter
+     */
+    public static FastISOTimestampFormatter isoInstant(ZoneId zoneId) {
+        FastISOTimestampFormatter fast = new FastISOTimestampFormatter(DateTimeFormatter.ISO_INSTANT.withZone(zoneId));
+        fast.setTrimMillis(false);
+        return fast;
+    }
+    
+    
+    /**
+     * State valid during a zone transition.
+     * Does not change frequently, typically before/after day-light transition.
+     */
+    private class ZoneOffsetState {
+        private final long zoneTransitionStart;
+        private final long zoneTransitionStop;
+        private final boolean cachingEnabled;
+        private TimestampCache cache;
+        
+        ZoneOffsetState(long tstamp) {
+            // Determine how long we can cache the previous result.
+            // ZoneOffsets are usually expressed in hour:minutes but the Java time API accepts ZoneOffset with
+            // a resolution up to the second:
+            // - If the minutes/seconds parts of the ZoneOffset are zero, then we can cache for as long as one hour.
+            // - If the ZoneOffset is expressed in "minutes", then we can cache the date/hour/minute part for as long as a minute.
+            // - If the ZoneOffset is expressed in seconds, then we can cache only for one second.
+            //
+            // Also, take care of ZoneOffset transition (e.g. day light saving time).
+            
+            ZoneId zoneId = formatter.getZone();
+            if (zoneId == null) {
+                throw new IllegalArgumentException("formatter must be configured with a Zone override to format millis");
+            }
+            
+            Instant now = Instant.ofEpochMilli(tstamp);
+            ZoneOffset zoneOffset;
+            
+            /*
+             * The Zone has a fixed offset that will never change.
+             */
+            if (zoneId.getRules().isFixedOffset()) {
+                zoneOffset = zoneId.getRules().getOffset(now);
+                this.zoneTransitionStart = 0;
+                this.zoneTransitionStop = Long.MAX_VALUE;
+            }
+            /*
+             * The Zone has multiple offsets. Determine the one applicable at the given timestamp
+             * and how long it is valid.
+             */
+            else {
+                ZoneOffsetTransition zoneOffsetTransition = zoneId.getRules().nextTransition(now);
+                this.zoneTransitionStart = tstamp;
+                this.zoneTransitionStop = zoneOffsetTransition.toEpochSecond() * 1_000;
+                zoneOffset = zoneOffsetTransition.getOffsetBefore();
+            }
+
+            /*
+             * Determine the precision of the zone offset.
+             * 
+             * If the offset is expressed with HH:mm without seconds, then the date/time part remains constant during
+             * one minute and is not affected by the zone offset. This means we can safely deduce the second and millis
+             * from a long timestamp.
+             * 
+             * The same applies for the minutes part if the offset contains hours only. In this case, the date/time part
+             * remains constant for a complete hour increasing the time we can reuse that part. However, tests have shown
+             * that the extra computation required to extract the minutes from the timestamp during rendering negatively
+             * impact the overall performance.
+             * 
+             * Caching is therefore limited to one minute which is good enough for our usage.
+             */
+            int offsetSeconds = zoneOffset.getTotalSeconds();
+            this.cachingEnabled = (offsetSeconds % 60 == 0);
+        }
+        
+        
+        /**
+         * Check whether this state is applicable for the given timestamp.
+         * 
+         * @param tstamp the timestamp millis
+         * @return {@code true} if this state is applicable to the given timestamp
+         */
+        public boolean isApplicable(long tstamp) {
+            return tstamp >= this.zoneTransitionStart && tstamp < this.zoneTransitionStop;
+        }
+        
+        
+        /**
+         * Format the timestamp millis.
+         * Note: you must first invoke {@link #isApplicable(long)} to check that the state can be used to format the timestamp.
+         * 
+         * @param tstamp the timestamp milis to format
+         * @return the formatted timestamp
+         */
+        public String format(long tstamp) {
+            // If caching is disabled...
+            //
+            if (!this.cachingEnabled) {
+                return buildFromFormatter(tstamp);
+            }
+            
+            // If tstamp is within the caching period...
+            //
+            TimestampCache currentCache = this.cache;
+            if (currentCache != null && currentCache.isApplicable(tstamp)) {
+                return buildFromCache(currentCache, tstamp);
+            }
+            
+            // ... otherwise, use the formatter and cache the formatted value
+            //
+            String formatted = buildFromFormatter(tstamp);
+            cache = createNewCache(tstamp, formatted);
+            return formatted;
+        }
+        
+        
+        private TimestampCache createNewCache(long timestampInMillis, String formatted) {
+            // The part up to the minutes (included)
+            String prefix = formatted.substring(0, 17);
+                
+            // The part after the millis (i.e. the timezone)
+            // Note:
+            //   ISO_LOCAL_DATE_TIME has nothing after millis
+            //   ISO_INSTANT has a 'Z'
+            int pos = formatted.indexOf('+', 17);
+            if (pos == -1) {
+                pos = formatted.indexOf('-', 17);
+            }
+            if (pos == -1 && formatted.charAt(formatted.length() - 1) == 'Z') {
+                pos = formatted.length() - 1;
+            }
+            String suffix = pos == -1 ? "" : formatted.substring(pos);
+            
+            // Determine how long we can use this cache
+            long cachePeriod = timestampInMillis / 60_000;
+            long cacheStart = cachePeriod * 60_000;
+            long cacheStop = (cachePeriod + 1) * 60_000;
+
+            // Store in cache
+            return new TimestampCache(cacheStart, cacheStop, prefix, suffix);
+        }
+        
+        
+        private String buildFromCache(TimestampCache cache, long timestampInMillis) {
+            return cache.format(timestampInMillis);
+        }
+    }
+    
+    String buildFromFormatter(long timestampInMillis) {
+        return FastISOTimestampFormatter.this.formatter.format(Instant.ofEpochMilli(timestampInMillis));
+    }
+    
+    private class TimestampCache {
+        private final long cacheStart;
+        private final long cacheStop;
+        private final String suffix;
+        private final String prefix;
+
+        TimestampCache(long cacheStart, long cacheStop, String prefix, String suffix) {
+            this.cacheStart = cacheStart;
+            this.cacheStop = cacheStop;
+            this.prefix = prefix;
+            this.suffix = suffix;
+        }
+        
+        public boolean isApplicable(long tstamp) {
+            return tstamp >= this.cacheStart && tstamp < this.cacheStop;
+        }
+        
+        public String format(long timestampInMillis) {
+            StringBuilder sb = STRING_BUILDERS.get();
+            sb.setLength(0);
+            sb.append(prefix);
+            
+            int millisSinceCacheStart = (int) (timestampInMillis - this.cacheStart); // seconds & millis
+            int seconds = millisSinceCacheStart / 1_000;
+            int millis = millisSinceCacheStart % 1000;
+
+            // seconds are always TWO digits...
+            //
+            if (seconds < 10) {
+                sb.append('0');
+            }
+            sb.append(seconds);
+            
+            
+            // millis are optional, max 3 significant digits (trailing 0 removed)
+            //
+            if (millis > 0) {
+                int dotPos = sb.length();
+                sb.append('.');
+                
+                // add leading 0...
+                if (millis < 100) {
+                    sb.append('0');
+                }
+                if (millis < 10) {
+                    sb.append('0');
+                }
+                
+                // add millis value...
+                sb.append(millis);
+                
+                // remove trailing 0...
+                if (FastISOTimestampFormatter.this.trimMillis) {
+                    while (sb.length() > dotPos) {
+                        if (sb.charAt(sb.length() - 1) == '0') {
+                            sb.setLength(sb.length() - 1);
+                        }
+                        else {
+                            break;
+                        }
+                    }
+                }
+            }
+            
+            // suffix...
+            //
+            sb.append(this.suffix);
+            
+            return sb.toString();
+        }
+    }
+}

--- a/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
+++ b/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
@@ -35,7 +35,7 @@ import java.time.zone.ZoneOffsetTransition;
 import java.time.zone.ZoneOffsetTransitionRule;
 import java.time.zone.ZoneRules;
 import java.time.zone.ZoneRulesProvider;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -83,14 +83,23 @@ public class FastISOTimestampFormatterTest {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> FastISOTimestampFormatter.isoOffsetDateTime(null));
     }
     
-    
+    @Test
+    public void a() {
+        ZonedDateTime now = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, 123000000, zone);
+
+        System.out.println(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(now));
+        System.out.println(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(now));
+        System.out.println(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(now));
+        System.out.println(DateTimeFormatter.ISO_DATE_TIME.format(now));
+        System.out.println(DateTimeFormatter.ISO_INSTANT.format(now));
+    }
     /*
      * Check that caching of previous values works as expected
      */
     @Test
     public void checkCaching() {
         DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zone);
-        FastISOTimestampFormatter fast = spy(new FastISOTimestampFormatter(formatter));
+        FastISOTimestampFormatter fast = spy(new FastISOTimestampFormatter(formatter, true));
         
         ZonedDateTime now = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, 0, zone);
 
@@ -205,7 +214,7 @@ public class FastISOTimestampFormatterTest {
         // At least one transition is required
         ZoneOffsetTransition initialTransition = ZoneOffsetTransition.of(
                 LocalDateTime.of(2000, 1, 1, 3, 0), summerTimeOffset, winterTimeOffset);
-        List<ZoneOffsetTransition> transitionList = listOf(initialTransition);
+        List<ZoneOffsetTransition> transitionList = Arrays.asList(initialTransition);
 
         // Winter->Summer: switch around Jan 1st @ 2AM
         ZoneOffsetTransitionRule springRule =
@@ -218,7 +227,7 @@ public class FastISOTimestampFormatterTest {
                         false, ZoneOffsetTransitionRule.TimeDefinition.STANDARD, winterTimeOffset,
                         summerTimeOffset, winterTimeOffset);
         ZoneRules rules = ZoneRules.of(winterTimeOffset, winterTimeOffset,
-                transitionList, transitionList, listOf(springRule, fallRule));
+                transitionList, transitionList, Arrays.asList(springRule, fallRule));
 
         // Register the new custom rule - the heart of the magic: the ZoneRulesProvider
         Set<String> zoneIds = new HashSet<>();
@@ -336,7 +345,7 @@ public class FastISOTimestampFormatterTest {
      * Create a collection of DynamicTests, one for each supported time format
      */
     private static Collection<DynamicTest> doForAllSupportedFormats(ZoneId zone, TestCase testCase) {
-        return listOf(
+        return Arrays.asList(
             DynamicTest.dynamicTest("ISO_OFFSET_DATE_TIME", () ->
                 testCase.execute(
                     DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zone),
@@ -422,15 +431,5 @@ public class FastISOTimestampFormatterTest {
         finally {
             verify(fast, times(1)).buildFromFormatter(millis);
         }
-    }
-    
-    
-    @SafeVarargs
-    private static <T> List<T> listOf(T... items) {
-        ArrayList<T> l = new ArrayList<>();
-        for (T item: items) {
-            l.add(item);
-        }
-        return l;
     }
 }

--- a/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
+++ b/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
@@ -83,16 +83,7 @@ public class FastISOTimestampFormatterTest {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> FastISOTimestampFormatter.isoOffsetDateTime(null));
     }
     
-    @Test
-    public void a() {
-        ZonedDateTime now = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, 123000000, zone);
 
-        System.out.println(DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(now));
-        System.out.println(DateTimeFormatter.ISO_ZONED_DATE_TIME.format(now));
-        System.out.println(DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(now));
-        System.out.println(DateTimeFormatter.ISO_DATE_TIME.format(now));
-        System.out.println(DateTimeFormatter.ISO_INSTANT.format(now));
-    }
     /*
      * Check that caching of previous values works as expected
      */

--- a/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
+++ b/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
@@ -1,0 +1,436 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.composite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneOffsetTransitionRule;
+import java.time.zone.ZoneRules;
+import java.time.zone.ZoneRulesProvider;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.mockito.Mockito;
+
+
+/**
+ * @author brenuart
+ *
+ */
+public class FastISOTimestampFormatterTest {
+    // ===========================================================================================================
+    //
+    //                                              !! WARNING !!
+    //
+    // Remember the FastISOTimestampFormatter "caches" part of the formatted string during 1 minute.
+    // When the minute is over (and cache discarded) a new formatted string is built using a DateTimeFormatter.
+    // If you test the class by formatting a single value, the caching feature will not be used and the formatted
+    // string will come directly from the DateTimeFormatter...
+    //
+    // See #invokeTwice(...) below.
+    //
+    // ===========================================================================================================
+    
+    private ZoneId zone = ZoneId.of("Europe/Brussels");
+
+    
+    /*
+     * The DateTimeFormatter must have the "zone" overridden or an IllegalArgumentException is thrown
+     */
+    @Test
+    public void zoneMustBeOverridden() {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> FastISOTimestampFormatter.isoOffsetDateTime(null));
+    }
+    
+    
+    /*
+     * Check that caching of previous values works as expected
+     */
+    @Test
+    public void checkCaching() {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zone);
+        FastISOTimestampFormatter fast = spy(new FastISOTimestampFormatter(formatter));
+        
+        ZonedDateTime now = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, 0, zone);
+
+        // Cache is empty - first call comes from the DateTimeFormatter
+        assertThat(isNotFromCache(fast, now.toInstant())).isEqualTo(formatter.format(now));
+
+        
+        //
+        // Stay within the same minute (i.e. within cache validity)
+        //
+        
+        // Second call with same date/time comes from the cache
+        assertThat(isFromCache(fast, now.toInstant())).isEqualTo(formatter.format(now));
+        
+        // Next calls within the same minute come from the cache as well
+        ZonedDateTime current = now.plusSeconds(29);
+        assertThat(isFromCache(fast, current.toInstant())).isEqualTo(formatter.format(current));
+
+        
+        //
+        // Move forward to next minute
+        //
+        current = now.plusMinutes(1);
+        assertThat(isNotFromCache(fast, current.toInstant())).isEqualTo(formatter.format(current));
+        
+        current = current.plusSeconds(29);
+        assertThat(isFromCache(fast, current.toInstant())).isEqualTo(formatter.format(current));
+        
+        
+        //
+        // Go backwards
+        //
+        current = now.minusMinutes(1);
+        assertThat(isNotFromCache(fast, current.toInstant())).isEqualTo(formatter.format(current));
+    }
+    
+    
+    /*
+     * Check that millis are expressed with the minimal required number of digits
+     */
+    @TestFactory
+    public Collection<DynamicTest> checkMillisDigits() {
+        return doForAllSupportedFormats(zone, (formatter, fast) -> {
+            // Warm the cache
+            Instant instant = ZonedDateTime.of(2020, 01, 01, 10, 20, 0, 0, zone).toInstant();
+            assertThat(fast.format(instant.toEpochMilli())).isEqualTo(formatter.format(instant));
+
+            // millis: 0
+            instant = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, 0, zone).toInstant();
+            assertThat(fast.format(instant.toEpochMilli())).isEqualTo(formatter.format(instant));
+
+            // millis: .001 (3 decimals)
+            instant = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, (int) TimeUnit.MILLISECONDS.toNanos(1), zone).toInstant();
+            assertThat(fast.format(instant.toEpochMilli())).isEqualTo(formatter.format(instant));
+            
+            // millis: .01 (2 decimals)
+            instant = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, (int) TimeUnit.MILLISECONDS.toNanos(10), zone).toInstant();
+            assertThat(fast.format(instant.toEpochMilli())).isEqualTo(formatter.format(instant));
+            
+            // millis: .1 (1 decimals)
+            instant = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, (int) TimeUnit.MILLISECONDS.toNanos(100), zone).toInstant();
+            assertThat(fast.format(instant.toEpochMilli())).isEqualTo(formatter.format(instant));
+            
+            // millis: .123 (3 decimals)
+            instant = ZonedDateTime.of(2020, 01, 01, 10, 20, 30, (int) TimeUnit.MILLISECONDS.toNanos(123), zone).toInstant();
+            assertThat(fast.format(instant.toEpochMilli())).isEqualTo(formatter.format(instant));
+        });
+    }
+    
+    
+    /*
+     * Assert day-light transitions are OK
+     */
+    @TestFactory
+    public Collection<DynamicTest> daylightTransition() {
+        // [Europe/Brussels] has day light transition
+        //
+        ZoneId zoneId = ZoneId.of("Europe/Brussels");
+        
+        Instant now = Instant.now();
+        ZoneOffsetTransition zoneOffsetTransition = zoneId.getRules().nextTransition(now);
+        
+       
+        return doForAllSupportedFormats(zoneId, (formatter, fast) -> {
+            // Before the transition
+            ZonedDateTime before = zoneOffsetTransition.getDateTimeBefore().atZone(zoneId).minusMinutes(1);
+            assertThat(invokeTwice(fast, before.toInstant())).isEqualTo(formatter.format(before));
+                
+            // After the transition
+            ZonedDateTime after = zoneOffsetTransition.getDateTimeAfter().atZone(zoneId).plusMinutes(1);
+            assertThat(invokeTwice(fast, after.toInstant())).isEqualTo(formatter.format(after));
+        });
+    }
+    
+    
+    /*
+     * Create a custom TimeZone with two rules and offsets expressed with different precision:
+     * - winter has an offset in HOURS
+     * - summer has an offset in HOURS:MINUTES
+     * 
+     * The "fast" algorithm will be disabled during "summer" because of the "seconds" precision.
+     */
+    @TestFactory
+    public Collection<DynamicTest> customTimeZone() {
+        //
+        // Create the custom TimeZone
+        //
+        final String customZoneId = "Custom-TimeZone";
+
+        final ZoneOffset winterTimeOffset = ZoneOffset.ofHoursMinutes(1, 30);
+        final ZoneOffset summerTimeOffset = ZoneOffset.ofHoursMinutesSeconds(2, 30, 15);
+        // At least one transition is required
+        ZoneOffsetTransition initialTransition = ZoneOffsetTransition.of(
+                LocalDateTime.of(2000, 1, 1, 3, 0), summerTimeOffset, winterTimeOffset);
+        List<ZoneOffsetTransition> transitionList = listOf(initialTransition);
+
+        // Winter->Summer: switch around Jan 1st @ 2AM
+        ZoneOffsetTransitionRule springRule =
+                ZoneOffsetTransitionRule.of(Month.JANUARY, 1, DayOfWeek.MONDAY, LocalTime.of(2, 0),
+                        false, ZoneOffsetTransitionRule.TimeDefinition.STANDARD, winterTimeOffset,
+                        winterTimeOffset, summerTimeOffset);
+        // Summer->Winter: switch around Oct 1st @ 2AM
+        ZoneOffsetTransitionRule fallRule =
+                ZoneOffsetTransitionRule.of(Month.OCTOBER, -1, DayOfWeek.SUNDAY, LocalTime.of(2, 0),
+                        false, ZoneOffsetTransitionRule.TimeDefinition.STANDARD, winterTimeOffset,
+                        summerTimeOffset, winterTimeOffset);
+        ZoneRules rules = ZoneRules.of(winterTimeOffset, winterTimeOffset,
+                transitionList, transitionList, listOf(springRule, fallRule));
+
+        // Register the new custom rule - the heart of the magic: the ZoneRulesProvider
+        Set<String> zoneIds = new HashSet<>();
+        zoneIds.add(customZoneId);
+        
+        ZoneRulesProvider customProvider = new ZoneRulesProvider() {
+            @Override
+            protected Set<String> provideZoneIds() {
+                return zoneIds;
+            }
+
+            @Override
+            protected NavigableMap<String, ZoneRules> provideVersions(String zoneId) {
+                TreeMap<String, ZoneRules> map = new TreeMap<>();
+                map.put(customZoneId, rules);
+                return map;
+            }
+
+            @Override
+            protected ZoneRules provideRules(String zoneId, boolean forCaching) {
+                return rules;
+            }
+        };
+
+        // Registering the ZoneRulesProvider is the key to ZoneId using it
+        ZoneRulesProvider.registerProvider(customProvider);
+        
+        
+        
+        //
+        // TestCase:
+        //
+        // Render times before and after the winter/summer transition.
+        //
+        ZoneId zoneId = ZoneId.of(customZoneId);
+        
+        Instant now = Instant.now();
+        ZoneOffsetTransition zoneOffsetTransition = zoneId.getRules().nextTransition(now);
+        
+        ZonedDateTime before = zoneOffsetTransition.getDateTimeBefore().atZone(ZoneId.systemDefault()).minusMinutes(1);
+        ZonedDateTime after = zoneOffsetTransition.getDateTimeAfter().atZone(ZoneId.systemDefault()).plusMinutes(1);
+
+        return doForAllSupportedFormats(zoneId, (formatter, fast) -> {
+            assertThat(invokeTwice(fast, before.toInstant())).isEqualTo(formatter.format(before));
+            
+            assertThat(invokeTwice(fast, after.toInstant())).isEqualTo(formatter.format(after));
+        });
+    }
+    
+    
+    
+    /*
+     * Invoke same formatter from concurrent threads. Force invalidation of the cache by making
+     * one thread going forward and the other backwards.
+     * 
+     * Note that this test is not an accurate proof that everything is OK in multi-threaded
+     * environment... but it is better than nothing.
+     */
+    @Test
+    public void threadSafety() {
+        
+        final DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(zone);
+        final FastISOTimestampFormatter fast = FastISOTimestampFormatter.isoZonedDateTime(zone);
+        
+        ZonedDateTime now = ZonedDateTime.of(2020, 01, 01, 10, 20, 0, 0, zone);
+        
+        ExecutorService execService = Executors.newCachedThreadPool();
+
+        try {
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            
+            Future<Void> result1 = execService.submit(() -> {
+                    barrier.await();
+                    
+                    ZonedDateTime current = now;
+                    for (int i = 0; i < 3600; i++) {
+                        assertThat(fast.format(current.toInstant().toEpochMilli())).isEqualTo(formatter.format(current));
+                        current = current.plusSeconds(1);
+                    }
+                    
+                    return null;
+                });
+            
+            Future<Void> result2 = execService.submit(() -> {
+                barrier.await();
+                
+                ZonedDateTime current = now;
+                for (int i = 0; i < 3600; i++) {
+                    assertThat(fast.format(current.toInstant().toEpochMilli())).isEqualTo(formatter.format(current));
+                    current = current.minusSeconds(1);
+                }
+                
+                return null;
+            });
+            
+            assertThatCode(() -> result1.get()).doesNotThrowAnyException();
+            assertThatCode(() -> result2.get()).doesNotThrowAnyException();
+        }
+        finally {
+            execService.shutdownNow();
+        }
+    }
+    
+    
+    // --------------------------------------------------------------------------------------------
+    
+    
+    @FunctionalInterface
+    interface TestCase {
+        void execute(DateTimeFormatter formatter, FastISOTimestampFormatter fast);
+    }
+    
+    
+    /*
+     * Create a collection of DynamicTests, one for each supported time format
+     */
+    private static Collection<DynamicTest> doForAllSupportedFormats(ZoneId zone, TestCase testCase) {
+        return listOf(
+            DynamicTest.dynamicTest("ISO_OFFSET_DATE_TIME", () ->
+                testCase.execute(
+                    DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(zone),
+                    FastISOTimestampFormatter.isoOffsetDateTime(zone))),
+            
+            DynamicTest.dynamicTest("ISO_ZONED_DATE_TIME", () ->
+                testCase.execute(
+                    DateTimeFormatter.ISO_ZONED_DATE_TIME.withZone(zone),
+                    FastISOTimestampFormatter.isoZonedDateTime(zone))),
+            
+            DynamicTest.dynamicTest("ISO_LOCAL_DATE_TIME", () ->
+                testCase.execute(
+                    DateTimeFormatter.ISO_LOCAL_DATE_TIME.withZone(zone),
+                    FastISOTimestampFormatter.isoLocalDateTime(zone))),
+            
+            DynamicTest.dynamicTest("ISO_DATE_TIME", () ->
+                testCase.execute(
+                    DateTimeFormatter.ISO_DATE_TIME.withZone(zone),
+                    FastISOTimestampFormatter.isoDateTime(zone))),
+
+            DynamicTest.dynamicTest("ISO_INSTANT", () ->
+                testCase.execute(
+                    DateTimeFormatter.ISO_INSTANT.withZone(zone),
+                    FastISOTimestampFormatter.isoInstant(zone))));
+    }
+
+    
+    /**
+     * Invoke the FastISOTimestampFormatter twice to force the result to come out of the
+     * cache if enabled.
+     * 
+     * @param fast the fast formatter
+     * @param instant the instant to format
+     * @return the formatted result
+     */
+    private static String invokeTwice(FastISOTimestampFormatter fast, Instant instant) {
+        long millis = instant.toEpochMilli();
+        
+        // Format a first time to "warm" the cache
+        fast.format(millis);
+        
+        // Format a second time - value should come out of the cache
+        return fast.format(millis);
+    }
+
+    
+    /**
+     * Format the {@code instant} using the supplied {@link FastISOTimestampFormatter} {@code fast}
+     * formatter and assert that the result is generated from the internal cache instead of the
+     * enclosed DateTimeFormatter.
+     * 
+     * @param fast the fast formatter
+     * @param instant the instant to format
+     * @return the formatted result
+     */
+    private static String isFromCache(FastISOTimestampFormatter fast, Instant instant) {
+        Mockito.clearInvocations(fast);
+        long millis = instant.toEpochMilli();
+        try {
+            return fast.format(millis);
+        }
+        finally {
+            verify(fast, times(0)).buildFromFormatter(millis);
+        }
+    }
+
+    /**
+     * Format the {@code instant} using the supplied {@link FastISOTimestampFormatter} {@code fast}
+     * formatter and assert that the result is generated from the enclosed DateTimeFormatter and does
+     * not come from the internal cache.
+     * 
+     * @param fast the fast formatter
+     * @param instant the instant to format
+     * @return the formatted result
+     */
+    private static String isNotFromCache(FastISOTimestampFormatter fast, Instant instant) {
+        Mockito.clearInvocations(fast);
+        
+        long millis = instant.toEpochMilli();
+        try {
+            return fast.format(millis);
+        }
+        finally {
+            verify(fast, times(1)).buildFromFormatter(millis);
+        }
+    }
+    
+    
+    @SafeVarargs
+    private static <T> List<T> listOf(T... items) {
+        ArrayList<T> l = new ArrayList<>();
+        for (T item: items) {
+            l.add(item);
+        }
+        return l;
+    }
+}

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProviderTest.java
@@ -70,12 +70,12 @@ public class LoggingEventFormattedTimestampJsonProviderTest {
     @Test
     public void constant() throws IOException {
         LoggingEventFormattedTimestampJsonProvider provider = new LoggingEventFormattedTimestampJsonProvider();
-        provider.setPattern("[ISO_DATE_TIME]");
+        provider.setPattern("[RFC_1123_DATE_TIME]"); // use a DateTimeFormatter pattern not supported by the FastISOTimestampFormatter
         when(event.getTimeStamp()).thenReturn(0L);
 
         provider.writeTo(generator, event);
 
-        String expectedValue = DateTimeFormatter.ISO_DATE_TIME.withZone(TimeZone.getDefault().toZoneId()).format(Instant.ofEpochMilli(0));
+        String expectedValue = DateTimeFormatter.RFC_1123_DATE_TIME.withZone(TimeZone.getDefault().toZoneId()).format(Instant.ofEpochMilli(0));
         verify(generator).writeStringField(AbstractFormattedTimestampJsonProvider.FIELD_TIMESTAMP, expectedValue);
     }
 


### PR DESCRIPTION
The FastISOTimestampFormatter is a fast alternative to Java's DateTimeFormatter for the most commonly used ISO formats, i.e.:
- ISO_OFFSET_DATE_TIME
- ISO_ZONED_DATE_TIME
- ISO_LOCAL_DATE_TIME
- ISO_DATE_TIME
- ISO_INSTANT

Instead of computing every date/time fields every time it is invoked like the standard DateTimeFormatter does, the fast formatter remembers the previous formatted value and uses it to replace only the second and millis parts if the next timestamp to format is within the same minute.

This new formatter is currently used only when the `FormattedTimestampJsonProvider` is configured with one of default format listed above (expressed between `[]` in the configuration). A standard DateTimeFormatter is used for the other standard formats or if a custom pattern is configured (even if the pattern matches one of the supported formats). We can extend support for other formats if needed...

To highlight the benefits I ran a quick benchmark whose only job is to format `System.currentTimeMillis()` as fast as possible. This test is of course not representative of any real world scenario but it gives a fair overview of the differences between the two approaches.
```
                           Thrpt (ops/s)      Mem alloc (B/op)
--------------------------------------------------------------
FastISOTimestampFormatter       14212725                    87
DateTimeFormatter                2021980                   973
```
As we can see, the "fast" formatter is 7x faster and produces 10x less garbage.

I then ran the "LogstashEncoder" benchmark to see how it performs with the new fast formatter. This benchmark invokes the LogstashEncoder as fast as it can during 3 rounds of 10 seconds each. I also ran it against LLE 7.01 and 6.6:

```
                                          Thrpt (ops/s)    Mem alloc (B/op)
---------------------------------------------------------------------------
7.1-SNAPSHOT (FastISOTimestampFormatter)        1185035                 846
7.0.1        (DateTimeFormatter)                 751877                1755
6.6          (DateTimeFormatter)                 764514                2752
```

We can see that `7.1-SNAPSHOT` is nearly 50% faster than `7.0.1` and produces 50% less garbage. 
`7.0.1` and `6.6` have roughly the same throughput but `7.0.1` produces less memory allocation. This is due to the reuse of the Jackson JsonFactory introduced in 7.0.

-------------

Pending things todo:
- [ ] update README.md
- [x] update release note