### PR TITLE
getFieldValue() should return `fieldValue` without transforming it into a String

### DIFF
--- a/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/ObjectAppendingMarker.java
@@ -94,8 +94,8 @@ public class ObjectAppendingMarker extends SingleFieldAppendingMarker {
     }
 
     @Override
-    public Object getFieldValue() {
-        return StructuredArguments.toString(fieldValue);
+    protected Object getFieldValue() {
+        return fieldValue;
     }
 
     @Override

--- a/src/main/java/net/logstash/logback/marker/RawJsonAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/RawJsonAppendingMarker.java
@@ -66,7 +66,7 @@ public class RawJsonAppendingMarker extends SingleFieldAppendingMarker {
     }
 
     @Override
-    public Object getFieldValue() {
+    protected Object getFieldValue() {
         return rawJson;
     }
 

--- a/src/main/java/net/logstash/logback/marker/SingleFieldAppendingMarker.java
+++ b/src/main/java/net/logstash/logback/marker/SingleFieldAppendingMarker.java
@@ -129,7 +129,7 @@ public abstract class SingleFieldAppendingMarker extends LogstashMarker implemen
      * 
      * @return the field value
      */
-    public abstract Object getFieldValue();
+    protected abstract Object getFieldValue();
 
     @Override
     public boolean equals(Object obj) {


### PR DESCRIPTION
`ObjectAppendingMarker#getFieldValue()` should ideally return the value of the `fieldValue` property without transformation. This method is intended to be used by `SingleFieldAppendingMarker#selfToString()` that already takes care of converting the value into a String.

closes #719