### PR TITLE
Custom JsonGenerator with optimized writeObject() for simple object types

### DIFF
--- a/src/main/java/net/logstash/logback/composite/AbstractCompositeJsonFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractCompositeJsonFormatter.java
@@ -26,6 +26,7 @@ import net.logstash.logback.decorate.JsonGeneratorDecorator;
 import net.logstash.logback.decorate.NullJsonFactoryDecorator;
 import net.logstash.logback.decorate.NullJsonGeneratorDecorator;
 import net.logstash.logback.util.ProxyOutputStream;
+import net.logstash.logback.util.SimpleObjectJsonGeneratorDelegate;
 import net.logstash.logback.util.ThreadLocalHolder;
 
 import ch.qos.logback.access.spi.IAccessEvent;
@@ -283,7 +284,7 @@ public abstract class AbstractCompositeJsonFormatter<Event extends DeferredProce
     }
 
     private JsonGenerator decorateGenerator(JsonGenerator generator) {
-        return this.jsonGeneratorDecorator.decorate(generator)
+        return new SimpleObjectJsonGeneratorDelegate(jsonGeneratorDecorator.decorate(generator)
                /*
                 * When generators are flushed, don't flush the underlying outputStream.
                 *
@@ -306,10 +307,9 @@ public abstract class AbstractCompositeJsonFormatter<Event extends DeferredProce
 
                /*
                 * JsonGenerator are reused to serialize multiple log events.
-                * Change the default root value separator to an empty string.
+                * Change the default root value separator to an empty string instead of a single space.
                 */
-               .setRootValueSeparator(new SerializedString(CoreConstants.EMPTY_STRING));
-
+               .setRootValueSeparator(new SerializedString(CoreConstants.EMPTY_STRING)));
     }
     
     public JsonFactory getJsonFactory() {

--- a/src/main/java/net/logstash/logback/composite/JsonWritingUtils.java
+++ b/src/main/java/net/logstash/logback/composite/JsonWritingUtils.java
@@ -16,22 +16,12 @@
 package net.logstash.logback.composite;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Utilities for writing JSON
@@ -179,161 +169,5 @@ public class JsonWritingUtils {
      */
     public static boolean shouldWriteField(String fieldName) {
         return fieldName != null && !fieldName.equals(LogstashCommonFieldNames.IGNORE_FIELD_INDICATOR);
-    }
-
-    /**
-     * Helper method to try to call appropriate write method for given
-     * untyped Object. Delegates to {@link JsonGenerator#writeObject(Object)} if the value
-     * cannot be efficiently handled by this method.
-     *
-     * @param generator the {@link JsonGenerator} to produce JSON content
-     * @param value Value to write
-     *
-     * @throws IOException if there is either an underlying I/O problem or encoding
-     *    issue at format layer
-     */
-    public static void writeObject(JsonGenerator generator, Object value) throws IOException {
-        if (value == null) {
-            generator.writeNull();
-            return;
-        }
-        else if (value instanceof String) {
-            generator.writeString((String) value);
-            return;
-        }
-        else if (value instanceof Number) {
-            Number n = (Number) value;
-            if (n instanceof Integer) {
-                generator.writeNumber(n.intValue());
-                return;
-            }
-            if (n instanceof Long) {
-                generator.writeNumber(n.longValue());
-                return;
-            }
-            if (n instanceof Double) {
-                generator.writeNumber(n.doubleValue());
-                return;
-            }
-            if (n instanceof Float) {
-                generator.writeNumber(n.floatValue());
-                return;
-            }
-            if (n instanceof Short) {
-                generator.writeNumber(n.shortValue());
-                return;
-            }
-            if (n instanceof Byte) {
-                generator.writeNumber(n.byteValue());
-                return;
-            }
-            if (n instanceof BigInteger) {
-                generator.writeNumber((BigInteger) n);
-                return;
-            }
-            if (n instanceof BigDecimal) {
-                generator.writeNumber((BigDecimal) n);
-                return;
-            }
-            if (n instanceof AtomicInteger) {
-                generator.writeNumber(((AtomicInteger) n).get());
-                return;
-            }
-            if (n instanceof AtomicLong) {
-                generator.writeNumber(((AtomicLong) n).get());
-                return;
-            }
-        }
-        else if (value instanceof byte[]) {
-            generator.writeBinary((byte[]) value);
-            return;
-        }
-        else if (value instanceof Boolean) {
-            generator.writeBoolean((Boolean) value);
-            return;
-        }
-        else if (value instanceof AtomicBoolean) {
-            generator.writeBoolean(((AtomicBoolean) value).get());
-            return;
-        }
-        else if (value instanceof JsonNode) {
-            JsonNode node = (JsonNode) value;
-            
-            switch (node.getNodeType()) {
-                case NULL:
-                    generator.writeNull();
-                    return;
-                    
-                case STRING:
-                    generator.writeString(node.asText());
-                    return;
-                    
-                case BOOLEAN:
-                    generator.writeBoolean(node.asBoolean());
-                    return;
-                    
-                case BINARY:
-                    generator.writeBinary(node.binaryValue());
-                    return;
-                    
-                case NUMBER:
-                    if (node.isInt()) {
-                        generator.writeNumber(node.intValue());
-                        return;
-                    }
-                    if (node.isLong()) {
-                        generator.writeNumber(node.longValue());
-                        return;
-                    }
-                    if (node.isShort()) {
-                        generator.writeNumber(node.shortValue());
-                        return;
-                    }
-                    if (node.isDouble()) {
-                        generator.writeNumber(node.doubleValue());
-                        return;
-                    }
-                    if (node.isFloat()) {
-                        generator.writeNumber(node.floatValue());
-                        return;
-                    }
-                    if (node.isBigDecimal()) {
-                        generator.writeNumber(node.decimalValue());
-                        return;
-                    }
-                    if (node.isBigInteger()) {
-                        generator.writeNumber(node.bigIntegerValue());
-                        return;
-                    }
-                    
-                case OBJECT:
-                    generator.writeStartObject(node);
-                    for (Iterator<Entry<String, JsonNode>> entries = ((ObjectNode) node).fields(); entries.hasNext();) {
-                        Entry<String, JsonNode> entry = entries.next();
-                        generator.writeFieldName(entry.getKey());
-                        writeObject(generator, entry.getValue());
-                    }
-                    generator.writeEndObject();
-                    return;
-                    
-                case ARRAY:
-                    ArrayNode arrayNode = (ArrayNode) node;
-                    int size = arrayNode.size();
-                    generator.writeStartArray(arrayNode, size);
-                    for (Iterator<JsonNode> elements = arrayNode.elements(); elements.hasNext();) {
-                        writeObject(generator, elements.next());
-                    }
-                    generator.writeEndArray();
-                    return;
-                    
-                default:
-                    // default case is handled below
-                    break;
-            }
-        }
-
-        // Default case if not handled by one of the specialized methods above
-        //
-        generator.writeObject(value);
     }
 }

--- a/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
@@ -27,7 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.logstash.logback.composite.JsonReadingUtils;
-import net.logstash.logback.composite.JsonWritingUtils;
 import net.logstash.logback.util.StringUtils;
 
 import ch.qos.logback.core.Context;
@@ -454,7 +453,7 @@ public abstract class AbstractJsonPatternParser<Event> {
         }
 
         public void write(JsonGenerator generator, Event event) throws IOException {
-            JsonWritingUtils.writeObject(generator, getValue(event));
+            generator.writeObject(getValue(event));
         }
         
         private Object getValue(Event event) {

--- a/src/main/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegate.java
+++ b/src/main/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegate.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.util;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.JsonGeneratorDelegate;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * JsonGenerator with an optimized implementation of the {@link #writeObject(Object)} method that tries
+ * to call appropriate write method for the given untyped Object and delegates to the underlying generator
+ * as fallback.
+ */
+public class SimpleObjectJsonGeneratorDelegate extends JsonGeneratorDelegate {
+    public SimpleObjectJsonGeneratorDelegate(JsonGenerator delegate) {
+        super(delegate, false);
+    }
+    
+    @Override
+    public void writeObject(Object value) throws IOException {
+        if (value == null) {
+            writeNull();
+            return;
+        }
+        if (value instanceof String) {
+            writeString((String) value);
+            return;
+        }
+        if (value instanceof Number) {
+            Number n = (Number) value;
+            if (n instanceof Integer) {
+                writeNumber(n.intValue());
+                return;
+            }
+            if (n instanceof Long) {
+                writeNumber(n.longValue());
+                return;
+            }
+            if (n instanceof Double) {
+                writeNumber(n.doubleValue());
+                return;
+            }
+            if (n instanceof Float) {
+                writeNumber(n.floatValue());
+                return;
+            }
+            if (n instanceof Short) {
+                writeNumber(n.shortValue());
+                return;
+            }
+            if (n instanceof Byte) {
+                writeNumber(n.byteValue());
+                return;
+            }
+            if (n instanceof BigInteger) {
+                writeNumber((BigInteger) n);
+                return;
+            }
+            if (n instanceof BigDecimal) {
+                writeNumber((BigDecimal) n);
+                return;
+            }
+            if (n instanceof AtomicInteger) {
+                writeNumber(((AtomicInteger) n).get());
+                return;
+            }
+            if (n instanceof AtomicLong) {
+                writeNumber(((AtomicLong) n).get());
+                return;
+            }
+        }
+        if (value instanceof byte[]) {
+            writeBinary((byte[]) value);
+            return;
+        }
+        if (value instanceof Boolean) {
+            writeBoolean((Boolean) value);
+            return;
+        }
+        if (value instanceof AtomicBoolean) {
+            writeBoolean(((AtomicBoolean) value).get());
+            return;
+        }
+        if (value instanceof JsonNode) {
+            JsonNode node = (JsonNode) value;
+            
+            switch (node.getNodeType()) {
+                case NULL:
+                    writeNull();
+                    return;
+                    
+                case STRING:
+                    writeString(node.asText());
+                    return;
+                    
+                case BOOLEAN:
+                    writeBoolean(node.asBoolean());
+                    return;
+                    
+                case BINARY:
+                    writeBinary(node.binaryValue());
+                    return;
+                    
+                case NUMBER:
+                    if (node.isInt()) {
+                        writeNumber(node.intValue());
+                        return;
+                    }
+                    if (node.isLong()) {
+                        writeNumber(node.longValue());
+                        return;
+                    }
+                    if (node.isShort()) {
+                        writeNumber(node.shortValue());
+                        return;
+                    }
+                    if (node.isDouble()) {
+                        writeNumber(node.doubleValue());
+                        return;
+                    }
+                    if (node.isFloat()) {
+                        writeNumber(node.floatValue());
+                        return;
+                    }
+                    if (node.isBigDecimal()) {
+                        writeNumber(node.decimalValue());
+                        return;
+                    }
+                    if (node.isBigInteger()) {
+                        writeNumber(node.bigIntegerValue());
+                        return;
+                    }
+                    
+                case OBJECT:
+                    writeStartObject(node);
+                    for (Iterator<Entry<String, JsonNode>> entries = ((ObjectNode) node).fields(); entries.hasNext();) {
+                        Entry<String, JsonNode> entry = entries.next();
+                        writeObjectField(entry.getKey(), entry.getValue());
+                    }
+                    writeEndObject();
+                    return;
+                    
+                case ARRAY:
+                    ArrayNode arrayNode = (ArrayNode) node;
+                    int size = arrayNode.size();
+                    writeStartArray(arrayNode, size);
+                    for (Iterator<JsonNode> elements = arrayNode.elements(); elements.hasNext();) {
+                        writeObject(elements.next());
+                    }
+                    writeEndArray();
+                    return;
+                    
+                default:
+                    // default case is handled below
+                    break;
+            }
+        }
+        
+
+        // Default case if not handled by one of the specialized methods above
+        //
+        delegate.writeObject(value);
+    }
+}

--- a/src/test/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegateTests.java
+++ b/src/test/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegateTests.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.FloatNode;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ShortNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -90,25 +91,27 @@ public class SimpleObjectJsonGeneratorDelegateTests {
     
     @Test
     public void writeObject_Numbers() throws IOException {
-        generator.writeObject((short) 1);
-        generator.writeObject((int) 2);
-        generator.writeObject((long) 3);
-        generator.writeObject((double) 4);
-        generator.writeObject((float) 5);
-        generator.writeObject(BigInteger.valueOf(6));
-        generator.writeObject(BigDecimal.valueOf(7));
-        generator.writeObject(new AtomicInteger(8));
-        generator.writeObject(new AtomicLong(9));
+        generator.writeObject((byte) 1);
+        generator.writeObject((short) 2);
+        generator.writeObject((int) 3);
+        generator.writeObject((long) 4);
+        generator.writeObject((double) 5);
+        generator.writeObject((float) 6);
+        generator.writeObject(BigInteger.valueOf(7));
+        generator.writeObject(BigDecimal.valueOf(8));
+        generator.writeObject(new AtomicInteger(9));
+        generator.writeObject(new AtomicLong(10));
         
-        verify(delegate).writeNumber((short) 1);
-        verify(delegate).writeNumber((int) 2);
-        verify(delegate).writeNumber((long) 3);
-        verify(delegate).writeNumber((double) 4);
-        verify(delegate).writeNumber((float) 5);
-        verify(delegate).writeNumber(BigInteger.valueOf(6));
-        verify(delegate).writeNumber(BigDecimal.valueOf(7));
-        verify(delegate).writeNumber((int) 8);
-        verify(delegate).writeNumber((long) 9);
+        verify(delegate).writeNumber((byte) 1);
+        verify(delegate).writeNumber((short) 2);
+        verify(delegate).writeNumber((int) 3);
+        verify(delegate).writeNumber((long) 4);
+        verify(delegate).writeNumber((double) 5);
+        verify(delegate).writeNumber((float) 6);
+        verify(delegate).writeNumber(BigInteger.valueOf(7));
+        verify(delegate).writeNumber(BigDecimal.valueOf(8));
+        verify(delegate).writeNumber((int) 9);
+        verify(delegate).writeNumber((long) 10);
     }
     
     
@@ -188,6 +191,14 @@ public class SimpleObjectJsonGeneratorDelegateTests {
         verify(delegate).writeBoolean(true);
         verify(delegate).writeNumber((int) 1);
         verify(delegate).writeEndArray();
+    }
+    
+    
+    @Test
+    public void writeObject_jsonNode_Null() throws IOException {
+        generator.writeObject(NullNode.instance);
+        
+        verify(delegate).writeNull();
     }
     
     

--- a/src/test/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegateTests.java
+++ b/src/test/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegateTests.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BigIntegerNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.DecimalNode;
+import com.fasterxml.jackson.databind.node.DoubleNode;
+import com.fasterxml.jackson.databind.node.FloatNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.ShortNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author brenuart
+ *
+ */
+public class SimpleObjectJsonGeneratorDelegateTests {
+
+    private static final JsonFactory FACTORY = new MappingJsonFactory();
+
+    private JsonGenerator delegate;
+    private SimpleObjectJsonGeneratorDelegate generator;
+    
+    @BeforeEach
+    public void setup() throws IOException {
+        delegate = spy(FACTORY.createGenerator(new StringWriter()));
+        generator = new SimpleObjectJsonGeneratorDelegate(delegate);
+    }
+    
+    @Test
+    public void writeObject_Null() throws IOException {
+        generator.writeObject(null);
+        
+        verify(delegate).writeNull();
+    }
+    
+    
+    @Test
+    public void writeObject_String() throws IOException {
+        generator.writeObject("foo");
+        
+        verify(delegate).writeString("foo");
+    }
+    
+    
+    @Test
+    public void writeObject_Boolean() throws IOException {
+        generator.writeObject(Boolean.TRUE);
+        generator.writeObject(new AtomicBoolean(false));
+        
+        verify(delegate).writeBoolean(true);
+        verify(delegate).writeBoolean(false);
+    }
+    
+    
+    @Test
+    public void writeObject_Numbers() throws IOException {
+        generator.writeObject((short) 1);
+        generator.writeObject((int) 2);
+        generator.writeObject((long) 3);
+        generator.writeObject((double) 4);
+        generator.writeObject((float) 5);
+        generator.writeObject(BigInteger.valueOf(6));
+        generator.writeObject(BigDecimal.valueOf(7));
+        generator.writeObject(new AtomicInteger(8));
+        generator.writeObject(new AtomicLong(9));
+        
+        verify(delegate).writeNumber((short) 1);
+        verify(delegate).writeNumber((int) 2);
+        verify(delegate).writeNumber((long) 3);
+        verify(delegate).writeNumber((double) 4);
+        verify(delegate).writeNumber((float) 5);
+        verify(delegate).writeNumber(BigInteger.valueOf(6));
+        verify(delegate).writeNumber(BigDecimal.valueOf(7));
+        verify(delegate).writeNumber((int) 8);
+        verify(delegate).writeNumber((long) 9);
+    }
+    
+    
+    @Test
+    public void writeObject_byteArray() throws IOException {
+        byte[] data = new byte[] {1, 2};
+        generator.writeObject(data);
+        
+        verify(delegate).writeBinary(any(), eq(data), eq(0), eq(2));
+    }
+    
+    
+    @Test
+    public void writeObject_jsonNode_String() throws IOException {
+        generator.writeObject(new TextNode("foo"));
+    }
+    
+    
+    @Test
+    public void writeObject_jsonNode_Numbers() throws IOException {
+        generator.writeObject(new IntNode(1));
+        generator.writeObject(new LongNode(2));
+        generator.writeObject(new ShortNode((short) 3));
+        generator.writeObject(new FloatNode(4));
+        generator.writeObject(new DoubleNode(5));
+        generator.writeObject(new BigIntegerNode(BigInteger.valueOf(6)));
+        generator.writeObject(new DecimalNode(BigDecimal.valueOf(7)));
+        
+        verify(delegate).writeNumber((int) 1);
+        verify(delegate).writeNumber((long) 2);
+        verify(delegate).writeNumber((short) 3);
+        verify(delegate).writeNumber((float) 4);
+        verify(delegate).writeNumber((double) 5);
+        verify(delegate).writeNumber(BigInteger.valueOf(6));
+        verify(delegate).writeNumber(BigDecimal.valueOf(7));
+    }
+    
+    
+    @Test
+    public void writeObject_jsonNode_Boolean() throws IOException {
+        generator.writeObject(BooleanNode.TRUE);
+        
+        verify(delegate).writeBoolean(true);
+    }
+
+    
+    @Test
+    public void writeObject_jsonNode_Object() throws IOException {
+        ObjectNode node = (ObjectNode) generator.getCodec().createObjectNode();
+        node.put("string", "foo");
+        node.put("boolean", true);
+        
+        generator.writeObject(node);
+        
+        verify(delegate).getCodec();
+        verify(delegate).writeStartObject(any());
+        verify(delegate).writeFieldName("string");
+        verify(delegate).writeString("foo");
+        verify(delegate).writeFieldName("boolean");
+        verify(delegate).writeBoolean(true);
+        verify(delegate).writeEndObject();
+    }
+    
+    
+    @Test
+    public void writeObject_jsonNode_Array() throws IOException {
+        ArrayNode node = (ArrayNode) generator.getCodec().createArrayNode();
+        node.add("string");
+        node.add(true);
+        node.add(1);
+        
+        generator.writeObject(node);
+        
+        verify(delegate).getCodec();
+        verify(delegate).writeStartArray(any(), eq(3));
+        verify(delegate).writeString("string");
+        verify(delegate).writeBoolean(true);
+        verify(delegate).writeNumber((int) 1);
+        verify(delegate).writeEndArray();
+    }
+    
+    
+    @Test
+    public void writeObject_POJO() throws IOException {
+        MyPojo obj = new MyPojo();
+        generator.writeObject(obj);
+        
+        verify(delegate).writeObject(obj);
+    }
+    
+    @SuppressWarnings("unused")
+    private static class MyPojo {
+        private String field = "foo";
+
+        public String getField() {
+            return field;
+        }
+        
+        public void setField(String field) {
+            this.field = field;
+        }
+    }
+}


### PR DESCRIPTION
Wrap the JsonGenerator with an optimized version of the writeObject() method that tries to call the appropriate write() method for the giveb untype Object and delegate to the underlying JsonGenerator as fallback.

Without this optimisation the writeObject() delegates to the underlying Codec which is less effective for simple types (String, Numbers, Boolean, byte[], JsonNode, etc) both in terms of CPU and temporary memory allocations.

Until now only the AbstractJsonPatternParser was using this optimisation. This commit moves it directly inside the JsonGenerator so it can benefit to any JsonProvider.