### PR TITLE
Make "%property{key}" return an empty string instead of "null" when used in PatternJsonProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1964,7 +1964,7 @@ The provider name is the xml element name to use when configuring.
         <ul>
           <li><tt>fieldName</tt> - Output field name (<tt>@timestamp</tt>)</li>
           <li><tt>pattern</tt> - Output format (<tt>[ISO_OFFSET_DATE_TIME]</tt>)  See <a href="#customizing-timestamp">above</a> for possible values.</li>
-          <li><tt>timeZone</tt> - Timezone (local timezone)</li>
+          <li><tt>timeZone</tt> - Timezone (system timezone)</li>
         </ul>
       </td>
     </tr>
@@ -2130,7 +2130,7 @@ The provider name is the xml element name to use when configuring. Each provider
         <ul>
           <li><tt>fieldName</tt> - Output field name (<tt>stack_hash</tt>)</li>
           <li><tt>exclude</tt> - Regular expression pattern matching <i>stack trace elements</i> to exclude when computing the error hash</li>
-          <li><tt>exclusions</tt> - Coma separated list of regular expression patterns matching <i>stack trace elements</i> to exclude when computing the error hash</li>
+          <li><tt>exclusions</tt> - Comma separated list of regular expression patterns matching <i>stack trace elements</i> to exclude when computing the error hash</li>
         </ul>
       </td>
     </tr>
@@ -2207,7 +2207,7 @@ The provider name is the xml element name to use when configuring. Each provider
         <ul>
           <li><tt>fieldName</tt> - Output field name (<tt>message</tt>)</li>
           <li><tt>pattern</tt> - Output format of the timestamp (<tt>[ISO_OFFSET_DATE_TIME]</tt>). See <a href="#customizing-timestamp">above</a> for possible values.</li>
-          <li><tt>timeZone</tt> - Timezone (local timezone)</li>
+          <li><tt>timeZone</tt> - Timezone (system timezone)</li>
         </ul>
       </td>
     </tr>
@@ -2383,10 +2383,10 @@ even for something which you may feel should be a number - like for `%b` (bytes 
 You can either deal with the type conversion on the logstash side or you may use special operations provided by this encoder.
 The operations are:
 
-* `#asLong{...}` - evaluates the pattern in curly braces and then converts resulting string to a Long (or a null if conversion fails).
-* `#asDouble{...}` - evaluates the pattern in curly braces and then converts resulting string to a Double (or a null if conversion fails).
-* `#asBoolean{...}`- evaluates the pattern in curly braces and then converts resulting string to a Boolean. Conversion is case insensitive. `true`, `yes`, `y` and `1` (case insensitive) are converted to a boolean `true`, a null or empty string is converted to `null`, anything else returns `false`.
-* `#asJson{...}` - evaluates the pattern in curly braces and then converts resulting string to json (or a null if conversion fails).
+* `#asLong{...}` - evaluates the pattern in curly braces and then converts resulting string to a Long (or a `null` if conversion fails).
+* `#asDouble{...}` - evaluates the pattern in curly braces and then converts resulting string to a Double (or a `null` if conversion fails).
+* `#asBoolean{...}`- evaluates the pattern in curly braces and then converts resulting string to a Boolean. Conversion is case insensitive. `true`, `yes`, `y` and `1` (case insensitive) are converted to a boolean `true`, a `null` or empty string is converted to `null`, anything else returns `false`.
+* `#asJson{...}` - evaluates the pattern in curly braces and then converts resulting string to json (or a `null` if conversion fails).
 * `#tryJson{...}` - evaluates the pattern in curly braces and then converts resulting string to json (or just the string if conversion fails).
 
 So this example...
@@ -2402,7 +2402,7 @@ So this example...
 </pattern>
 ```
 
-... And this logging code...
+... and this logging code...
 
 ```java
 MDC.put("hasMessage", "true");
@@ -2470,7 +2470,7 @@ If the MDC did not contain a `traceId` entry, then a JSON log event from the abo
 
 #### LoggingEvent patterns
 
-For LoggingEvents, patterns from logback-classic's
+For LoggingEvents, conversion specifiers from logback-classic's
 [`PatternLayout`](http://logback.qos.ch/manual/layouts.html#conversionWord) are supported.
 
 For example:
@@ -2496,10 +2496,14 @@ For example:
 </encoder>
 ```
 
+Note that the [`%property{key}`](https://logback.qos.ch/manual/layouts.html#property) conversion specifier behaves slightly differently when used in the context of the Pattern Json provider. If the property cannot be found in the logger context or the System properties, it returns **an empty string** instead of `null` as it would normally do. For example, assuming the "foo" property is not defined, `%property{foo}` would return `""` (an empty string) instead of `"null"` (a string whose content is made of 4 letters).
+
+The _property_ conversion specifier also allows you to specify a default value to use when the property is not defined. The default value is optional and can be specified using the `:-` operator as in Bash shell. For example, assuming the "foo" property is not defined, `%property{foo:-bar}` will return `bar`.
+
 
 #### AccessEvent patterns
 
-For AccessEvents, patterns from logback-access's
+For AccessEvents, conversion specifiers from logback-access's
 [`PatternLayout`](http://logback.qos.ch/xref/ch/qos/logback/access/PatternLayout.html) are supported.
 
 For example:  
@@ -2529,9 +2533,9 @@ For example:
 
 There is also a special operation that can be used with this AccessEvents:
 
-* `#nullNA{...}` - if the pattern in curly braces evaluates to a dash ("-"), it will be replaced with a null value.
+* `#nullNA{...}` - if the pattern in curly braces evaluates to a dash (`-`), it will be replaced with a `null` value.
 
-You may want to use it because many of the `PatternLayout` conversion specifiers from logback-access will evaluate to "-"
+You may want to use it because many of the `PatternLayout` conversion words from logback-access will evaluate to `-`
 for non-existent value (for example for a cookie, header or a request attribute).
 
 So the following pattern...

--- a/src/main/java/net/logstash/logback/pattern/EnhancedPropertyConverter.java
+++ b/src/main/java/net/logstash/logback/pattern/EnhancedPropertyConverter.java
@@ -25,9 +25,9 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextVO;
 
 /**
- * Variation of the legacy Logback {@link PropertyConverter} with the option to specify a
- * default value to use when the property does not exist instead of returning {@code null}
- * as does the original Logback implementation.
+ * Variation of the Logback {@link PropertyConverter} with the option to specify a default
+ * value to use when the property does not exist instead of returning {@code null} as does
+ * the original Logback implementation.
  * 
  * <p>The default value is optional and can be specified using the <code>:-</code> operator as
  * in Bash shell. For example, assuming the property "foo" is not defined, <code>%property{foo:-bar}</code>

--- a/src/main/java/net/logstash/logback/pattern/EnhancedPropertyConverter.java
+++ b/src/main/java/net/logstash/logback/pattern/EnhancedPropertyConverter.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.pattern;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import ch.qos.logback.classic.pattern.ClassicConverter;
+import ch.qos.logback.classic.pattern.PropertyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+
+/**
+ * Variation of the legacy Logback {@link PropertyConverter} with the option to specify a
+ * default value to use when the property does not exist instead of returning {@code null}
+ * as does the original Logback implementation.
+ * 
+ * <p>The default value is optional and can be specified using the <code>:-</code> operator as
+ * in Bash shell. For example, assuming the property "foo" is not defined, <code>%property{foo:-bar}</code>
+ * will return <code>bar</code>.
+ * If no optional value is declared, the converter returns an empty string instead of {@code null}
+ * if the property is not defined.
+ * 
+ * <p>The property resolution mechanism is the same as the Logback implementation. The property is
+ * first looked up in the context associated with the logging event. If not found, the property is
+ * searched in the System environment.
+ * 
+ * 
+ * @author brenuart
+ */
+public class EnhancedPropertyConverter extends ClassicConverter {
+    /**
+     * Regex pattern used to extract the optional default value from the key name.
+     */
+    private static final Pattern PATTERN = Pattern.compile("(.+):-(.*)");
+    
+    /**
+     * The property name.
+     */
+    private String propertyName;
+    
+    /**
+     * The default value to use when the property is not defined.
+     */
+    private String defaultValue = "";
+    
+    public void start() {
+        String optStr = getFirstOption();
+        if (optStr != null) {
+            propertyName = optStr;
+            super.start();
+        }
+        if (propertyName == null) {
+            throw new IllegalStateException("Property name is not specified");
+        }
+        
+        Matcher matcher = PATTERN.matcher(propertyName);
+        if (matcher.matches()) {
+            propertyName = matcher.group(1);
+            defaultValue = matcher.group(2);
+        }
+    }
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        LoggerContextVO lcvo = event.getLoggerContextVO();
+        Map<String, String> map = lcvo.getPropertyMap();
+        String val = map.get(propertyName);
+        
+        if (val == null) {
+            val = System.getProperty(propertyName);
+        }
+
+        if (val == null) {
+            val = defaultValue;
+        }
+        
+        return val;
+    }
+}

--- a/src/main/java/net/logstash/logback/pattern/EnhancedPropertyConverter.java
+++ b/src/main/java/net/logstash/logback/pattern/EnhancedPropertyConverter.java
@@ -44,9 +44,10 @@ import ch.qos.logback.classic.spi.LoggerContextVO;
  */
 public class EnhancedPropertyConverter extends ClassicConverter {
     /**
-     * Regex pattern used to extract the optional default value from the key name.
+     * Regex pattern used to extract the optional default value from the key name (split
+     * at the first :-).
      */
-    private static final Pattern PATTERN = Pattern.compile("(.+):-(.*)");
+    private static final Pattern PATTERN = Pattern.compile("(.+?):-(.*)");
     
     /**
      * The property name.

--- a/src/main/java/net/logstash/logback/pattern/LoggingEventJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/LoggingEventJsonPatternParser.java
@@ -30,9 +30,16 @@ public class LoggingEventJsonPatternParser extends AbstractJsonPatternParser<ILo
         super(context, jsonFactory);
     }
 
+    /**
+     * Create a new {@link PatternLayout} and replace the default {@code %property} converter
+     * with a {@link EnhancedPropertyConverter} to add support for default value in case the
+     * property is not defined.
+     */
     @Override
     protected PatternLayoutBase<ILoggingEvent> createLayout() {
-        return new PatternLayout();
+        PatternLayoutBase<ILoggingEvent> layout = new PatternLayout();
+        layout.getInstanceConverterMap().put("property", EnhancedPropertyConverter.class.getName());
+        return layout;
     }
 
 }

--- a/src/main/java/net/logstash/logback/pattern/PatternLayoutAdapter.java
+++ b/src/main/java/net/logstash/logback/pattern/PatternLayoutAdapter.java
@@ -144,7 +144,7 @@ public class PatternLayoutAdapter<E> {
     }
     
     /**
-     * Indicate whether the {@link PatternLayoutBase} always generates the same constant value independent of
+     * Indicate whether the {@link PatternLayoutBase} always generates the same constant value regardless of
      * the event it is given.
      * 
      * @return <em>true</em> if the pattern is constant


### PR DESCRIPTION
The behaviour of the `%property{key}` conversion specifier is slightly modified to return an empty string when the property is not defined instead of `null` as it normally does. Assuming the "foo" property does not exist, the following configuration:

```xml
<pattern>
   { "foo": "%property{foo}" }
</pattern>
```

... will produce something like this:
```json
{ "foo": "" }
```

... instead of:
```json
{ "foo": "null" }
```

The `foo` property will now be successfully omitted when `omitEmptyField` is `true`.

The property conversion specifier now also accepts an optional default value to use when the property does not exist. Assuming the property "foo" is not defined, `%property{foo:-bar}` will return `bar` instead of an empty string.

People wanting to revert to the original behaviour of returning "null" instead of an empty string can explicitly defined a default value of `"null"`.

This should close #765