### PR TITLE
773 PatternJsonProvider: provide a "asNullIfEmpty{...}" operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2386,6 +2386,7 @@ The operations are:
 * `#asLong{...}` - evaluates the pattern in curly braces and then converts resulting string to a Long (or a `null` if conversion fails).
 * `#asDouble{...}` - evaluates the pattern in curly braces and then converts resulting string to a Double (or a `null` if conversion fails).
 * `#asBoolean{...}`- evaluates the pattern in curly braces and then converts resulting string to a Boolean. Conversion is case insensitive. `true`, `yes`, `y` and `1` (case insensitive) are converted to a boolean `true`, a `null` or empty string is converted to `null`, anything else returns `false`.
+* `asNullIfEmpty{...}` - evaluates the pattern in curly braces and the converts resulting string into `null` if it is empty.
 * `#asJson{...}` - evaluates the pattern in curly braces and then converts resulting string to json (or a `null` if conversion fails).
 * `#tryJson{...}` - evaluates the pattern in curly braces and then converts resulting string to json (or just the string if conversion fails).
 

--- a/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
@@ -236,7 +236,7 @@ public abstract class AbstractJsonPatternParser<Event> {
     
     /**
      * Create a PatternLayout instance of the appropriate type. The returned instance
-     * will further configured with the context and appropriate pattern then started.
+     * will be further configured with the context and appropriate pattern then started.
      * 
      * @return an unstarted {@link PatternLayoutBase} instance
      */

--- a/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/AbstractJsonPatternParser.java
@@ -79,6 +79,7 @@ public abstract class AbstractJsonPatternParser<Event> {
         addOperation("asBoolean", new AsBooleanOperation());
         addOperation("asJson", new AsJsonOperation());
         addOperation("tryJson", new TryJsonOperation());
+        addOperation("asNullIfEmpty", new AsNullIfEmptyOperation());
     }
 
     /**
@@ -153,6 +154,13 @@ public abstract class AbstractJsonPatternParser<Event> {
             } catch (IOException e) {
                 throw new IllegalStateException("Unexpected IOException when reading JSON value (was '" + value + "')", e);
             }
+        }
+    }
+    
+    protected class AsNullIfEmptyOperation implements Operation<Object> {
+        @Override
+        public Object apply(String t) {
+            return StringUtils.isEmpty(t) ? null : t;
         }
     }
 

--- a/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
+++ b/src/test/java/net/logstash/logback/pattern/AbstractJsonPatternParserTest.java
@@ -230,6 +230,25 @@ public abstract class AbstractJsonPatternParserTest<Event> extends AbstractLogba
     }
     
     @Test
+    public void asNullIfEmpty() throws JsonPatternException {
+        String pattern = toJson(
+                "{                                    "
+              + "    'key1' : '#asNullIfEmpty{}',       "
+              + "    'key2' : '#asNullIfEmpty{ }',    "
+              + "    'key3' : '#asNullIfEmpty{foo}'   "
+              + "}                                    ");
+
+        String expected = toJson(
+                "{                                    "
+              + "    'key1' : null,                   "
+              + "    'key2' : ' ',                    "
+              + "    'key3' : 'foo'                   "
+              + "}                                    ");
+        
+        verifyFields(pattern, expected);
+    }
+    
+    @Test
     public void asJsonShouldTransformTextValueToJson() throws JsonPatternException {
 
         String pattern = toJson(


### PR DESCRIPTION
Add support for `#asNullIfEmpty{...}` operation in PatternJsonProvider.