### PR TITLE
Fix NullPointerException in the "after the last transition" case

### DIFF
--- a/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
+++ b/src/test/java/net/logstash/logback/composite/FastISOTimestampFormatterTest.java
@@ -18,6 +18,7 @@ package net.logstash.logback.composite;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -267,8 +268,14 @@ public class FastISOTimestampFormatterTest {
             assertThat(invokeTwice(fast, after.toInstant())).isEqualTo(formatter.format(after));
         });
     }
-    
-    
+
+    /*
+     * Assert after the last transitions are not exception
+     */
+    @Test
+    public void afterTheLastTransition() {
+        assertThatNoException().isThrownBy(() -> FastISOTimestampFormatter.isoOffsetDateTime(ZoneId.of("Asia/Bangkok")));
+    }
     
     /*
      * Invoke same formatter from concurrent threads. Force invalidation of the cache by making


### PR DESCRIPTION
When the timezone belong to the "after the last transition" case (ex: "Asia/Bangkok"), we'll get the `NullPointerException` at `FastISOTimestampFormatter`