### PR TITLE
ThreadLocalHolder: Optimize threadValues

### DIFF
--- a/src/main/java/net/logstash/logback/util/ThreadLocalHolder.java
+++ b/src/main/java/net/logstash/logback/util/ThreadLocalHolder.java
@@ -18,7 +18,8 @@ package net.logstash.logback.util;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Objects;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 
@@ -60,7 +61,7 @@ public class ThreadLocalHolder<T> {
     /**
      * Collection of values assigned to each thread
      */
-    protected final CopyOnWriteArrayList<HolderRef> threadValues = new CopyOnWriteArrayList<>(); /* visible for testing */
+    protected final Set<HolderRef> threadValues = ConcurrentHashMap.newKeySet(); /* visible for testing */
     
     /**
      * Reference to dead threads


### PR DESCRIPTION
Use a concurrent hash set instead of a CopyOnWriteArrayList.
threadValues.remove(...) is O(n) and also locks the
threadValues object which means that any other threads
that operate on it will block.

If there are many threads being created and killed,
the overhead of using CopyOnWriteArrayList
becomes significant.

Using as concurrent hash set (via ConcurrentHashMap),
add and remove become O(1) and avoids locking.