### PR TITLE
allow inline stacktrace generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1752,6 +1752,7 @@ is included in the logstash-logback-encoder library to format stacktraces by:
 * Using evaluators to determine if the stacktrace should be logged.
 * Outputting in either 'normal' order (root-cause-last), or root-cause-first.
 * Computing and inlining hexadecimal hashes for each exception stack using the `inlineHash` or `stackHash` provider ([more info](stack-hash.md)).
+* Use custom line separator for stack traces
 
 For example:
 
@@ -1766,6 +1767,7 @@ For example:
         <evaluator class="myorg.MyCustomEvaluator"/>
         <rootCauseFirst>true</rootCauseFirst>
         <inlineHash>true</inlineHash>
+        <lineSeparator>\\n</lineSeparator>
     </throwableConverter>
 </encoder>
 ```

--- a/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java
+++ b/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java
@@ -40,6 +40,7 @@ import ch.qos.logback.core.CoreConstants;
 import ch.qos.logback.core.boolex.EvaluationException;
 import ch.qos.logback.core.boolex.EventEvaluator;
 import ch.qos.logback.core.status.ErrorStatus;
+import net.logstash.logback.encoder.SeparatorParser;
 
 /**
  * A {@link ThrowableHandlingConverter} (similar to logback's {@link ThrowableProxyConverter})
@@ -303,8 +304,24 @@ public class ShortenedThrowableConverter extends ThrowableHandlingConverter {
         return lineSeparator;
     }
 
+    /**
+     * Sets which lineSeparator to use between events.
+     * <p>
+     *
+     * The following values have special meaning:
+     * <ul>
+     * <li>{@code null} or empty string = no new line.</li>
+     * <li>"{@code SYSTEM}" = operating system new line (default).</li>
+     * <li>"{@code UNIX}" = unix line ending ({@code \n}).</li>
+     * <li>"{@code WINDOWS}" = windows line ending {@code \r\n}).</li>
+     * </ul>
+     * <p>
+     * Any other value will be used as given as the lineSeparator.
+     *
+     * @param lineSeparator the line separator
+     */
     public void setLineSeparator(String lineSeparator) {
-        this.lineSeparator = lineSeparator;
+        this.lineSeparator = SeparatorParser.parseSeparator(lineSeparator);
     }
 
     /**

--- a/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java
+++ b/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java
@@ -118,8 +118,8 @@ public class ShortenedThrowableConverter extends ThrowableHandlingConverter {
     private static final int OPTION_INDEX_SHORTENED_CLASS_NAME = 1;
     private static final int OPTION_INDEX_MAX_LENGTH = 2;
 
-    /** String sequence to use to delimit lines instead of {@link CoreConstants#LINE_SEPARATOR} when {@link #inline} is active */
-    public static final String INLINE_SEPARATOR = "\\n";
+    /** String sequence to use to delimit lines instead of {@link CoreConstants#LINE_SEPARATOR} when inline is active */
+    public static final String DEFAULT_INLINE_SEPARATOR = "\\n";
 
     private AtomicInteger errorCount = new AtomicInteger();
 
@@ -165,10 +165,8 @@ public class ShortenedThrowableConverter extends ThrowableHandlingConverter {
      */
     private boolean inlineHash;
 
-    /**
-     * True to use "\\n" sequence instead of {@link CoreConstants#LINE_SEPARATOR}
-     */
-    private boolean inline;
+    /** line delimiter */
+    private String lineSeparator = CoreConstants.LINE_SEPARATOR;
 
     private StackElementFilter stackElementFilter;
 
@@ -236,7 +234,7 @@ public class ShortenedThrowableConverter extends ThrowableHandlingConverter {
                     } else if (OPTION_VALUE_INLINE_HASH.equals(option)) {
                         setInlineHash(true);
                     } else if (OPTION_VALUE_INLINE_STACK.equals(option)) {
-                        setInline(true);
+                        setLineSeparator(DEFAULT_INLINE_SEPARATOR);
                     } else {
                         @SuppressWarnings("rawtypes")
                         Map evaluatorMap = (Map) getContext().getObject(CoreConstants.EVALUATOR_MAP);
@@ -301,10 +299,12 @@ public class ShortenedThrowableConverter extends ThrowableHandlingConverter {
         return builder.toString();
     }
 
-    private String getLineSeparator() {
-        return isInline()
-                ? INLINE_SEPARATOR
-                : CoreConstants.LINE_SEPARATOR;
+    public String getLineSeparator() {
+        return lineSeparator;
+    }
+
+    public void setLineSeparator(String lineSeparator) {
+        this.lineSeparator = lineSeparator;
     }
 
     /**
@@ -623,14 +623,6 @@ public class ShortenedThrowableConverter extends ThrowableHandlingConverter {
 
     public void setInlineHash(boolean inlineHash) {
         this.inlineHash = inlineHash;
-    }
-
-    public boolean isInline() {
-        return inline;
-    }
-
-    public void setInline(boolean inlineHash) {
-        this.inline = inlineHash;
     }
 
     protected void setStackHasher(StackHasher stackHasher) {

--- a/src/test/java/net/logstash/logback/stacktrace/ShortenedThrowableConverterTest.java
+++ b/src/test/java/net/logstash/logback/stacktrace/ShortenedThrowableConverterTest.java
@@ -444,7 +444,7 @@ public class ShortenedThrowableConverterTest {
             String formatted = converter.convert(createEvent(e));
 
             // THEN
-            // verify we have expected stack hashes inlined
+            // verify we have the expected stack trace line separator inlined
             assertThat(formatted).doesNotContain(CoreConstants.LINE_SEPARATOR);
             assertThat(formatted).contains(ShortenedThrowableConverter.DEFAULT_INLINE_SEPARATOR);
         }

--- a/src/test/java/net/logstash/logback/stacktrace/ShortenedThrowableConverterTest.java
+++ b/src/test/java/net/logstash/logback/stacktrace/ShortenedThrowableConverterTest.java
@@ -315,7 +315,7 @@ public class ShortenedThrowableConverterTest {
         assertThat(converter.getShortenedClassNameLength()).isEqualTo(ShortenedThrowableConverter.FULL_CLASS_NAME_LENGTH);
         assertThat(converter.getMaxLength()).isEqualTo(ShortenedThrowableConverter.FULL_MAX_LENGTH);
         assertThat(converter.isRootCauseFirst()).isTrue();
-        assertThat(converter.isInline()).isFalse();
+        assertThat(converter.getLineSeparator()).isEqualTo(CoreConstants.LINE_SEPARATOR);
         assertThat(converter.getEvaluators().get(0)).isEqualTo(evaluator);
         assertThat(converter.getExcludes().get(0)).isEqualTo("regex");
         
@@ -326,7 +326,7 @@ public class ShortenedThrowableConverterTest {
         assertThat(converter.getMaxDepthPerThrowable()).isEqualTo(ShortenedThrowableConverter.SHORT_MAX_DEPTH_PER_THROWABLE);
         assertThat(converter.getShortenedClassNameLength()).isEqualTo(ShortenedThrowableConverter.SHORT_CLASS_NAME_LENGTH);
         assertThat(converter.getMaxLength()).isEqualTo(ShortenedThrowableConverter.SHORT_MAX_LENGTH);
-        assertThat(converter.isInline()).isTrue();
+        assertThat(converter.getLineSeparator()).isEqualTo(ShortenedThrowableConverter.DEFAULT_INLINE_SEPARATOR);
 
         // test numeric values
         converter.setOptionList(Arrays.asList("1", "2", "3"));
@@ -435,7 +435,7 @@ public class ShortenedThrowableConverterTest {
             // GIVEN
             StackHasher mockedHasher = Mockito.mock(StackHasher.class);
             ShortenedThrowableConverter converter = new ShortenedThrowableConverter();
-            converter.setInline(true);
+            converter.setLineSeparator(ShortenedThrowableConverter.DEFAULT_INLINE_SEPARATOR);
             converter.setRootCauseFirst(true);
             converter.start();
             converter.setStackHasher(mockedHasher);
@@ -446,7 +446,7 @@ public class ShortenedThrowableConverterTest {
             // THEN
             // verify we have expected stack hashes inlined
             assertThat(formatted).doesNotContain(CoreConstants.LINE_SEPARATOR);
-            assertThat(formatted).contains(ShortenedThrowableConverter.INLINE_SEPARATOR);
+            assertThat(formatted).contains(ShortenedThrowableConverter.DEFAULT_INLINE_SEPARATOR);
         }
     }
 


### PR DESCRIPTION
allow inline stacktrace generation, adding an `inline` option to `net.logstash.logback.stacktrace.ShortenedThrowableConverter`

ie:
```xml
    <conversionRule conversionWord="stack"
                       converterClass="net.logstash.logback.stacktrace.ShortenedThrowableConverter" />

    <property name="STACKTRACE_PATTERN" value="%stack{full,40,500,rootFirst,inline}"/>
    

    <property name="CONSOLE_LOG_PATTERN" value="%d%d{Z} %-5level [%15.15t] %-40.40logger{39} [%20.20marker] - %replace(%msg){'\n', '\\\\n'} || mdc=[%mdc] ${STACKTRACE_PATTERN} %n"/>
    
    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
		<encoder>
			<pattern>${CONSOLE_LOG_PATTERN}</pattern>
		</encoder>
	</appender>
```

result in a single line :
`
2022-05-10 11:06:46,859+0200 ERROR [           main] com.example.demo.DemoApplication         [                    ] - failure || mdc=[] java.lang.IllegalAccessException: a\n	at com.example.demo.DemoApplication.lambda$run$0(DemoApplication.java:40)\n	at o.springframework.boot.SpringApplication.callRunner(SpringApplication.java:777)\n	... 3 common frames omitted\nWrapped by: java.lang.IllegalStateException: Failed to execute CommandLineRunner\n	at o.springframework.boot.SpringApplication.callRunner(SpringApplication.java:780)\n	at o.springframework.boot.SpringApplication.callRunners(SpringApplication.java:761)\n	at o.springfr...\n
`

(useful for rsyslog or fluentd when you don't want to use `json` format)