### PR TITLE
Fetch Logback javadoc from https://javadoc.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,8 @@
                         <!-- Setup links to external api docs
                          -->
                         <links>
-                            <link>http://logback.qos.ch/apidocs</link>
+                            <link>https://javadoc.io/doc/ch.qos.logback/logback-core/${logback.version}</link>
+                            <link>https://javadoc.io/doc/ch.qos.logback/logback-classic/${logback.version}</link>
                             <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${jackson.version}</link>
                             <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jackson.version}</link>
                         </links>


### PR DESCRIPTION
Fetch Logback javadoc from https://javadoc.io instead of from Logback’s website:
- /package-list not available anymore from the official location
- the official website contains the doc for the very latest released version only without history