### PR TITLE
Bump to Logback 1.3.0-beta0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,12 @@ jobs:
         run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml verify
 
       # Run tests against Jackson 2.12 to ensure runtime compatibility (do not recompile)
-      - name: Test Jackson 2.12
-        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml -Djackson.version=2.12.5 surefire:test
+      - name: Test Jackson 2.12.x
+        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml -Pcompat-jackson surefire:test
+
+      # Run tests against Logback 1.2 to ensure runtime compatibility (do not recompile)
+      - name: Test Logback 1.2.x
+        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml -Pcompat-logback surefire:test
 
       - name: Upload Test Reports to Github
         uses: actions/upload-artifact@v2

--- a/pom.xml
+++ b/pom.xml
@@ -504,9 +504,20 @@
                         <!-- Setup links to external api docs
                          -->
                         <links>
+                        	<!-- Javadoc generation fails under Java8 because the Logback javadoc does not contain a
+                        	     "package-list" index file anymore since version 1.3.0. It seems to work however with
+                        	     Java 9 and 11.
+                        	     
+                        	     Note: "package-list" has been replaced by "element-list" in Java 9... Newer jdk versions
+                        	     seem to look for "element-list" first and fallback to "package-list".
+                        	     
+                        	     A possible workaround is to build the project (and generate javadoc) using Java 9 instead
+                        	     of 8. In the meantime links to Logback apidoc are commented.
+                        	     
                             <link>https://javadoc.io/doc/ch.qos.logback/logback-core/${logback.version}</link>
                             <link>https://javadoc.io/doc/ch.qos.logback/logback-classic/${logback.version}</link>
                             <link>https://javadoc.io/doc/ch.qos.logback/logback-access/${logback.version}</link>
+                            -->
                             <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${jackson.version}</link>
                             <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jackson.version}</link>
                         </links>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- runtime dependencies -->
         <jackson.version>2.13.3</jackson.version>
         <java-uuid-generator.version>4.0.1</java-uuid-generator.version>
-        <logback.version>1.2.11</logback.version>
+        <logback.version>1.3.0-beta0</logback.version>
 
         <!-- shaded runtime dependencies -->
         <disruptor.version>3.4.4</disruptor.version>
@@ -33,7 +33,7 @@
         <!-- test dependencies -->
         <assertj.version>3.22.0</assertj.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <javax-servlet-api.version>4.0.1</javax-servlet-api.version>
+        <jakarta-servlet-api.version>5.0.0</jakarta-servlet-api.version>
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.5.1</mockito.version>
 
@@ -64,6 +64,11 @@
 
         <!-- the server id the maven-release-plugin uses to obtain credentials to use when pushing tags/commits -->
         <project.scm.id>github</project.scm.id>
+        
+        <!-- Subdirectory below the surefire reports directory where to store test reports.
+             Used to differentiate between multiple test executions with different dependencies (used by Github CI)
+         -->
+        <surefire.reportsSubDir>default</surefire.reportsSubDir>
     </properties>
 
     <licenses>
@@ -155,12 +160,12 @@
             -->
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>${javax-servlet-api.version}</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+		    <groupId>jakarta.servlet</groupId>
+		    <artifactId>jakarta.servlet-api</artifactId>
+		    <version>${jakarta-servlet-api.version}</version>
+		    <scope>test</scope>
+		</dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
@@ -483,7 +488,7 @@
                             GitHub CI runs tests against different jackson versions.
                             Therefore, differentiate the report directories by jackson versions.
                         -->
-                        <reportsDirectory>${project.build.directory}/surefire-reports/jackson-${jackson.version}</reportsDirectory>
+                        <reportsDirectory>${project.build.directory}/surefire-reports/${surefire.reportsSubDir}</reportsDirectory>
                     </configuration>
                 </plugin>
                 
@@ -693,6 +698,37 @@
                 <license.skip>true</license.skip>
                 <checkstyle.skip>true</checkstyle.skip>
             </properties>
+        </profile>
+        
+        <!--
+        	Profile used to run backward compatibility tests against logback 1.2
+        -->
+        <profile>
+        	<id>compat-logback</id>
+        	<properties>
+        		<logback.version>1.2.11</logback.version>
+        		<surefire.reportsSubDir>logback-${logback.version}</surefire.reportsSubDir>
+        	</properties>
+        		<dependencies>
+        			<!-- Logback moved from javax.servlet to jakarta since version 1.3 -->
+			        <dependency>
+			            <groupId>javax.servlet</groupId>
+			            <artifactId>javax.servlet-api</artifactId>
+			            <version>4.0.1</version>
+			            <scope>test</scope>
+			        </dependency>
+        		</dependencies>
+        </profile>
+        
+        <!--
+        	Profile used to run backward compatibility tests against jackson 2.12
+        -->
+        <profile>
+        	<id>compat-jackson</id>
+        	<properties>
+        		<jackson.version>2.12.7</jackson.version>
+        		<surefire.reportsSubDir>jackson-${jackson.version}</surefire.reportsSubDir>
+        	</properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
- Build against Logback 1.3.0
- Execute backward compatibility tests against latest Logback 1.2.x
- Comment links to Logback javadoc (generation fails under Java8 because logback docs have replace "package-list" by "element-list")
