### PR TITLE
859 LogstashEncoder should throw IllegalArgumentException instead of logging an error status when attempting to use <providers>

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The structure of the output, and the data it contains, is fully configurable.
 * [Customizing AccessEvent Message](#customizing-accessevent-message)
 * [Customizing Logger Name Length](#customizing-logger-name-length)
 * [Customizing Stack Traces](#customizing-stack-traces)
+* [Registering Additional Providers](#registering-additional-providers)
 * [Prefix/Suffix/Separator](#prefixsuffixseparator)
 * [Composite Encoder/Layout](#composite-encoderlayout)
 	* [Providers common to LoggingEvents and AccessEvents](#providers-common-to-loggingevents-and-accessevents)
@@ -1815,6 +1816,37 @@ For example:
 
 [`ShortenedThrowableConverter`](/src/main/java/net/logstash/logback/stacktrace/ShortenedThrowableConverter.java)
 can even be used within a `PatternLayout` to format stacktraces in any non-JSON logs you may have.
+
+
+## Registering Additional Providers
+
+`LogstashEncoder`, `LogstashAccessEncoder` and their "layout" counterparts all come with a predefined set of encoders. You can register additional JsonProviders using the `<provider>` configuration property as shown in the following example:
+
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+    <!-- Add a new provider after those than come with the LogstashEncoder -->
+    <provider class="net.logstash.logback.composite.loggingevent.LoggingEventPatternJsonProvider">
+        <pattern>
+          {
+             "message": "%mdc{custom_value} %message"
+          }
+        </pattern>
+    </provider>
+
+    <!-- Disable the default message provider -->
+    <fieldNames>
+        <message>[ignore]</message>
+    </fieldNames>
+</encoder>
+```
+
+You can add several additional JsonProviders using multiple `<provider>` entries. They will appear just after the default providers registered by the LogstashEncoder.
+
+In this example, the pattern provider produces a "message" JSON field that will conflict with the message field produced by the MessageJsonProvider already registered by the LogstashEncoder itself. Different options to avoid the conflict:
+
+- you instruct LogstashEncoder to use a different field name using the [fieldNames](#customizing-standard-field-names) configuration property;
+- you disable the message provider that comes with the encoder (that's the option illustrated in the example above);
+- you use a different field name in your pattern.
 
 
 ## Prefix/Suffix/Separator

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -20,6 +20,7 @@ import java.util.List;
 import net.logstash.logback.LogstashFormatter;
 import net.logstash.logback.composite.AbstractCompositeJsonFormatter;
 import net.logstash.logback.composite.JsonProvider;
+import net.logstash.logback.composite.JsonProviders;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
 
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
@@ -228,5 +229,11 @@ public class LogstashEncoder extends LoggingEventCompositeJsonEncoder {
      */
     public void setMessageSplitRegex(String messageSplitRegex) {
         getFormatter().setMessageSplitRegex(messageSplitRegex);
+    }
+    
+    
+    @Override
+    public void setProviders(JsonProviders<ILoggingEvent> jsonProviders) {
+        throw new IllegalArgumentException("Using the <providers> configuration property is not allowed. Use <provider> instead to registerd additional " + JsonProvider.class.getSimpleName() + ".");
     }
 }

--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -20,6 +20,7 @@ import java.util.List;
 import net.logstash.logback.LogstashFormatter;
 import net.logstash.logback.composite.AbstractCompositeJsonFormatter;
 import net.logstash.logback.composite.JsonProvider;
+import net.logstash.logback.composite.JsonProviders;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
 
 import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
@@ -227,5 +228,11 @@ public class LogstashLayout extends LoggingEventCompositeJsonLayout {
      */
     public void setMessageSplitRegex(String messageSplitRegex) {
         getFormatter().setMessageSplitRegex(messageSplitRegex);
+    }
+    
+    
+    @Override
+    public void setProviders(JsonProviders<ILoggingEvent> jsonProviders) {
+        throw new IllegalArgumentException("Using the <providers> configuration property is not allowed. Use <provider> instead to registerd additional " + JsonProvider.class.getSimpleName() + ".");
     }
 }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -19,6 +19,7 @@ import static net.logstash.logback.marker.Markers.append;
 import static net.logstash.logback.marker.Markers.appendEntries;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import net.logstash.logback.composite.AbstractFormattedTimestampJsonProvider;
+import net.logstash.logback.composite.loggingevent.LoggingEventJsonProviders;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
 import net.logstash.logback.decorate.JsonGeneratorDecorator;
 import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
@@ -691,6 +693,12 @@ public class LogstashEncoderTest {
         assertThat(node.path("message").textValue()).isEqualTo(message);
     }
 
+    @Test
+    public void testJsonProvidersCannotBeChanged() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> encoder.setProviders(new LoggingEventJsonProviders()));
+    }
+    
     private void assertJsonArray(JsonNode jsonNode, String... expected) {
         assertThat(jsonNode).isNotNull();
         assertThat(jsonNode.isArray()).isTrue();


### PR DESCRIPTION
Make LogstashEncoder/Layout throw an IllegalArgumentException when an attempt is made to use the `<providers>` configuration property.
Also add a few words in the documentation about how to register additional JsonProvider to a LogstashEncoder.