### PR TITLE
allow set a flag to compile the pattern

### DIFF
--- a/src/main/java/net/logstash/logback/mask/MaskingJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/mask/MaskingJsonGeneratorDecorator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -173,6 +174,7 @@ public class MaskingJsonGeneratorDecorator implements JsonGeneratorDecorator, Li
          * The value to write as a mask for values that match the regex (can contain back references to capture groups in the regex).
          */
         private String mask = MaskingJsonGenerator.MASK;
+        private Integer flag = 0;
 
         public ValueMask() {
         }
@@ -217,6 +219,13 @@ public class MaskingJsonGeneratorDecorator implements JsonGeneratorDecorator, Li
          */
         public void setMask(String mask) {
             this.mask = Objects.requireNonNull(mask);
+        }
+
+        /**
+         * @param flag to compile the patter. {@link Pattern#MULTILINE} for example
+         */
+        public void setFlag(Integer flag) {
+            this.flag = flag;
         }
     }
 
@@ -285,7 +294,7 @@ public class MaskingJsonGeneratorDecorator implements JsonGeneratorDecorator, Li
         return Collections.unmodifiableList(Stream.concat(
                         Stream.concat(Stream.of(valuesWithDefaultMask), valueMaskSuppliers.stream().map(Supplier::get))
                                 .flatMap(valueMask -> valueMask.values.stream()
-                                        .map(value -> new RegexValueMasker(value, valueMask.mask))),
+                                        .map(value -> new RegexValueMasker(value, valueMask.mask, valueMask.flag))),
                         valueMaskers.stream())
                 .collect(Collectors.toList()));
 

--- a/src/main/java/net/logstash/logback/mask/RegexValueMasker.java
+++ b/src/main/java/net/logstash/logback/mask/RegexValueMasker.java
@@ -32,9 +32,10 @@ public class RegexValueMasker implements ValueMasker {
     /**
      * @param regex the regex used to identify values to mask
      * @param mask the value to write for values that match the regex (can contain back references to capture groups in the regex)
+     * @param flag to compile the patter. {@link Pattern#MULTILINE} for example
      */
-    public RegexValueMasker(String regex, Object mask) {
-        this(Pattern.compile(regex), mask);
+    public RegexValueMasker(String regex, Object mask, Integer flag) {
+        this(Pattern.compile(regex, flag), mask);
     }
 
     /**


### PR DESCRIPTION
This PR allows to set a flag when configuring value masker ex:

```xml
<valueMask>
    <value>(?i)foo</value>
    <mask>*********</mask>
    <flag>8</flag>
</valueMask>
```

this example compiles the pattern with multiline