### PR TITLE
Bump build to JDK 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   build:
     name: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '11', '17' ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
 
   release:
     name: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [build]
     if: github.event_name == 'push' && github.repository == 'logfellow/logstash-logback-encoder' && github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, '[release]')
     steps:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 8
+          java-version: 17
 
       - name: Setup GPG
         run: .github/workflows/steps/setup-gpg.sh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: "temurin"
-        java-version: 8
+        java-version: 17
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </scm>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- runtime dependencies -->
@@ -39,6 +39,7 @@
 
         <!-- maven plugins -->
         <animal-sniffer-maven-plugin.version>1.22</animal-sniffer-maven-plugin.version>
+        <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
         <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
         <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
@@ -250,6 +251,7 @@
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
+                    <release>${java.version}</release>
                 </configuration>
             </plugin>
             <plugin>
@@ -265,7 +267,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8,)</version>
+                                    <version>[11,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>[3.5.0,)</version>
@@ -279,6 +281,9 @@
                                     <ignoreClasses>
                                         <ignoreClass>META-INF/versions/*</ignoreClass>
                                     </ignoreClasses>
+                                    <ignoredScopes>
+                                        <ignoredScope>test</ignoredScope>
+                                    </ignoredScopes>
                                 </enforceBytecodeVersion>
                             </rules>
                         </configuration>
@@ -288,7 +293,7 @@
                     <dependency>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>extra-enforcer-rules</artifactId>
-                        <version>1.6.1</version>
+                        <version>${extra-enforcer-rules.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
Still produce artifacts for Java 1.8.

Allows using maven plugins and test dependencies that require higher java versions.

Fixes #899