### PR TITLE
Add ability to customize the PrettyPrinter

### DIFF
--- a/src/main/java/net/logstash/logback/decorate/PrettyPrintingJsonGeneratorDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/PrettyPrintingJsonGeneratorDecorator.java
@@ -15,16 +15,51 @@
  */
 package net.logstash.logback.decorate;
 
+import ch.qos.logback.core.CoreConstants;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 
 /**
  * Enables pretty printing on the {@link JsonGenerator}
  */
 public class PrettyPrintingJsonGeneratorDecorator implements JsonGeneratorDecorator {
 
+    private DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter()
+            .withRootSeparator(CoreConstants.EMPTY_STRING);
+
     @Override
     public JsonGenerator decorate(JsonGenerator generator) {
-        return generator.useDefaultPrettyPrinter();
+        return generator.setPrettyPrinter(prettyPrinter);
     }
 
+    /**
+     * Sets the root separator used by the pretty printer.
+     *
+     * <p>Replaces occurrences of the string literal {@code [SPACE]} with a space character
+     * to work around the fact that logback trims values read from xml before calling the setter.
+     * Therefore, to set the root separator to a single space, you can specify
+     * {@code <rootSeparator>[SPACE]</rootSeparator>} in the xml configuration.</p>
+     *
+     * @param rootSeparator the new root separator
+     * @see DefaultPrettyPrinter#withRootSeparator(String)
+     */
+    public void setRootSeparator(String rootSeparator) {
+        prettyPrinter = prettyPrinter.withRootSeparator(
+                rootSeparator == null ? null : rootSeparator.replace("[SPACE]", " "));
+    }
+
+    /**
+     * Sets whether spaces appear in object entries.
+     *
+     * @param spacesInObjectEntries whether spaces appear in object entries.
+     * @see DefaultPrettyPrinter#withSpacesInObjectEntries()
+     * @see DefaultPrettyPrinter#withoutSpacesInObjectEntries()
+     */
+    public void setSpacesInObjectEntries(boolean spacesInObjectEntries) {
+        if (spacesInObjectEntries) {
+            prettyPrinter = prettyPrinter.withSpacesInObjectEntries();
+        } else {
+            prettyPrinter = prettyPrinter.withoutSpacesInObjectEntries();
+        }
+    }
 }

--- a/src/test/java/net/logstash/logback/decorate/PrettyPrintingJsonGeneratorDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/decorate/PrettyPrintingJsonGeneratorDecoratorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.decorate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Collections;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+
+class PrettyPrintingJsonGeneratorDecoratorTest {
+
+    @Test
+    void defaultOptions() throws IOException {
+        PrettyPrintingJsonGeneratorDecorator decorator = new PrettyPrintingJsonGeneratorDecorator();
+
+        StringWriter writer = new StringWriter();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonGenerator generator = decorator.decorate(objectMapper.createGenerator(writer));
+
+        generator.writeObject(Collections.singletonMap("key1", "value1"));
+        generator.writeObject(Collections.singletonMap("key2", "value2"));
+
+        generator.flush();
+        writer.flush();
+        assertThat(writer.toString()).isEqualTo("{\n  \"key1\" : \"value1\"\n}{\n  \"key2\" : \"value2\"\n}");
+    }
+
+    @Test
+    void customRootSeparator() throws IOException {
+        PrettyPrintingJsonGeneratorDecorator decorator = new PrettyPrintingJsonGeneratorDecorator();
+        decorator.setRootSeparator(" ");
+
+        StringWriter writer = new StringWriter();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonGenerator generator = decorator.decorate(objectMapper.createGenerator(writer));
+
+        generator.writeObject(Collections.singletonMap("key1", "value1"));
+        generator.writeObject(Collections.singletonMap("key2", "value2"));
+
+        generator.flush();
+        writer.flush();
+        assertThat(writer.toString()).isEqualTo("{\n  \"key1\" : \"value1\"\n} {\n  \"key2\" : \"value2\"\n}");
+    }
+
+    @Test
+    void customRootSeparatorWithSpace() throws IOException {
+        PrettyPrintingJsonGeneratorDecorator decorator = new PrettyPrintingJsonGeneratorDecorator();
+        decorator.setRootSeparator("[SPACE]");
+
+        StringWriter writer = new StringWriter();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonGenerator generator = decorator.decorate(objectMapper.createGenerator(writer));
+
+        generator.writeObject(Collections.singletonMap("key1", "value1"));
+        generator.writeObject(Collections.singletonMap("key2", "value2"));
+
+        generator.flush();
+        writer.flush();
+        assertThat(writer.toString()).isEqualTo("{\n  \"key1\" : \"value1\"\n} {\n  \"key2\" : \"value2\"\n}");
+    }
+
+    @Test
+    void noSpacesInObjectEntries() throws IOException {
+        PrettyPrintingJsonGeneratorDecorator decorator = new PrettyPrintingJsonGeneratorDecorator();
+        decorator.setSpacesInObjectEntries(false);
+
+        StringWriter writer = new StringWriter();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonGenerator generator = decorator.decorate(objectMapper.createGenerator(writer));
+
+        generator.writeObject(Collections.singletonMap("key1", "value1"));
+        generator.writeObject(Collections.singletonMap("key2", "value2"));
+
+        generator.flush();
+        writer.flush();
+        assertThat(writer.toString()).isEqualTo("{\n  \"key1\":\"value1\"\n}{\n  \"key2\":\"value2\"\n}");
+    }
+}


### PR DESCRIPTION
Add ability to customize the `PrettyPrinter` used by `PrettyPrintingJsonGeneratorDecorator`.

Specifically, add `rootSeparator` and `spacesInObjectEntries` fields.

Change default root separator used by the `PrettyPrinter` to an empty string to match the default `rootValueSeparator` used by the formatters. Previously, the default was a space (`" "`).  So this will slightly change the output when the `PrettyPrintingJsonGeneratorDecorator` is used. To revert to the old behavior, configure the decorator like this:

```xml
<jsonGeneratorDecorator class="net.logstash.logback.decorate.PrettyPrintingJsonGeneratorDecorator">
	<rootSeparator>[SPACE]</rootSeparator>
</jsonGeneratorDecorator>
```

Requested in discussion #906