### PR TITLE
Fix non-JSON generators

### DIFF
--- a/src/main/java/net/logstash/logback/decorate/yaml/YamlJsonFactoryDecorator.java
+++ b/src/main/java/net/logstash/logback/decorate/yaml/YamlJsonFactoryDecorator.java
@@ -18,6 +18,7 @@ package net.logstash.logback.decorate.yaml;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
 
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
@@ -35,6 +36,12 @@ public class YamlJsonFactoryDecorator implements JsonFactoryDecorator {
         YAMLFactory yamlFactory = new YAMLFactory();
         ObjectMapper mapper = new ObjectMapper(yamlFactory);
         yamlFactory.setCodec(mapper);
+        /*
+         * YAMLGenerator needs to pass the flush to the stream.
+         * It doesn't maintain an internal buffer like the other generators.
+         * To see this, look at the .flush() implementations of each of the generator classes.
+         */
+        yamlFactory.enable(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM);
         return yamlFactory;
     }
 }

--- a/src/test/java/net/logstash/logback/decorate/cbor/CborJsonFactoryDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/decorate/cbor/CborJsonFactoryDecoratorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.decorate.cbor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import net.logstash.logback.composite.loggingevent.LoggingEventCompositeJsonFormatter;
+import net.logstash.logback.composite.loggingevent.LoggingEventJsonProviders;
+import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.ContextAware;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CborJsonFactoryDecoratorTest {
+
+    @Mock
+    private ContextAware contextAware;
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Test
+    void test() throws IOException {
+        CborJsonFactoryDecorator decorator = new CborJsonFactoryDecorator();
+
+        LoggingEventJsonProviders providers = new LoggingEventJsonProviders();
+        providers.addMessage(new MessageJsonProvider());
+
+        LoggingEventCompositeJsonFormatter formatter = new LoggingEventCompositeJsonFormatter(contextAware);
+        formatter.setProviders(providers);
+        formatter.setJsonFactoryDecorator(decorator);
+        formatter.start();
+
+        when(event.getFormattedMessage()).thenReturn("a message");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        formatter.writeEvent(event, baos);
+
+        assertThat(baos.toByteArray()).asBase64Encoded().isEqualTo("v2dtZXNzYWdlaWEgbWVzc2FnZf8=");
+    }
+}

--- a/src/test/java/net/logstash/logback/decorate/smile/SmileJsonFactoryDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/decorate/smile/SmileJsonFactoryDecoratorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.decorate.smile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import net.logstash.logback.composite.loggingevent.LoggingEventCompositeJsonFormatter;
+import net.logstash.logback.composite.loggingevent.LoggingEventJsonProviders;
+import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.ContextAware;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SmileJsonFactoryDecoratorTest {
+
+    @Mock
+    private ContextAware contextAware;
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Test
+    void test() throws IOException {
+        SmileJsonFactoryDecorator decorator = new SmileJsonFactoryDecorator();
+
+        LoggingEventJsonProviders providers = new LoggingEventJsonProviders();
+        providers.addMessage(new MessageJsonProvider());
+
+        LoggingEventCompositeJsonFormatter formatter = new LoggingEventCompositeJsonFormatter(contextAware);
+        formatter.setProviders(providers);
+        formatter.setJsonFactoryDecorator(decorator);
+        formatter.start();
+
+        when(event.getFormattedMessage()).thenReturn("a message");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        formatter.writeEvent(event, baos);
+
+        assertThat(baos.toByteArray()).asBase64Encoded().isEqualTo("OikKAfqGbWVzc2FnZUhhIG1lc3NhZ2X7");
+    }
+}

--- a/src/test/java/net/logstash/logback/decorate/yaml/YamlJsonFactoryDecoratorTest.java
+++ b/src/test/java/net/logstash/logback/decorate/yaml/YamlJsonFactoryDecoratorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.logstash.logback.decorate.yaml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import net.logstash.logback.composite.loggingevent.LoggingEventCompositeJsonFormatter;
+import net.logstash.logback.composite.loggingevent.LoggingEventJsonProviders;
+import net.logstash.logback.composite.loggingevent.MessageJsonProvider;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.spi.ContextAware;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class YamlJsonFactoryDecoratorTest {
+
+    @Mock
+    private ContextAware contextAware;
+
+    @Mock
+    private ILoggingEvent event;
+
+    @Test
+    void test() throws IOException {
+        YamlJsonFactoryDecorator decorator = new YamlJsonFactoryDecorator();
+
+        LoggingEventJsonProviders providers = new LoggingEventJsonProviders();
+        providers.addMessage(new MessageJsonProvider());
+
+        LoggingEventCompositeJsonFormatter formatter = new LoggingEventCompositeJsonFormatter(contextAware);
+        formatter.setProviders(providers);
+        formatter.setJsonFactoryDecorator(decorator);
+        formatter.start();
+
+        when(event.getFormattedMessage()).thenReturn("a message");
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        formatter.writeEvent(event, baos);
+
+        assertThat(new String(baos.toByteArray(), StandardCharsets.UTF_8)).isEqualTo("---\nmessage: \"a message\"");
+    }
+
+}


### PR DESCRIPTION
non-JSON generators were broken in 7.0 when a call to `generator.setRootValueSeparator` was introduced.  The non-JSON generators throw `UnsupportedOperationException` when `setRootValueSeparator` is invoked.

Handle the `UnsupportedOperationException` properly.

Also moved disabling the `FLUSH_PASSED_TO_STREAM` generator feature to prior to decoration, because the YAML generation needs this feature enabled to work properly.

Introduced basic tests for non-JSON generators to catch the above problems in the future.

Fixes #919