### PR TITLE
Remove usage of the animal-sniffer-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <mockito.version>5.1.1</mockito.version>
 
         <!-- maven plugins -->
-        <animal-sniffer-maven-plugin.version>1.22</animal-sniffer-maven-plugin.version>
         <extra-enforcer-rules.version>1.6.1</extra-enforcer-rules.version>
         <license-maven-plugin.version>4.1</license-maven-plugin.version>
         <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
@@ -296,27 +295,6 @@
                         <version>${extra-enforcer-rules.version}</version>
                     </dependency>
                 </dependencies>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${animal-sniffer-maven-plugin.version}</version>
-                <configuration>
-                    <signature>
-                        <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java18</artifactId>
-                        <version>1.0</version>
-                    </signature>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>ensure-java-1.8-compatible</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
             <artifactId>java-uuid-generator</artifactId>
             <version>${java-uuid-generator.version}</version>
             <!--
-               Only needed if the UuidProvider is used.
+               Only needed if the UuidJsonProvider is used.
             -->
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
                     <release>${java.version}</release>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Not required anymore since #890 - this is now handled by the compiler itself and its new <release> argument.
Closes #931