### PR TITLE
Add provider for slf4j key-value attributes

### DIFF
--- a/src/main/java/net/logstash/logback/composite/KeyValueAttributeLogstashJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/KeyValueAttributeLogstashJsonProvider.java
@@ -1,0 +1,29 @@
+package net.logstash.logback.composite;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.slf4j.event.KeyValuePair;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+public class KeyValueAttributeLogstashJsonProvider extends AbstractJsonProvider<ILoggingEvent> {
+    public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
+        for (KeyValuePair keyValuePair : event.getKeyValuePairs()) {
+            String key = keyValuePair.key;
+            Object value = keyValuePair.value;
+            if (value == null) generator.writeNullField(key);
+            else if (value instanceof String) generator.writeStringField(key, (String) value);
+            else if (value instanceof Boolean) generator.writeBooleanField(key, (Boolean) value);
+            else if (value instanceof Integer) generator.writeNumberField(key, (Integer) value);
+            else if (value instanceof Long) generator.writeNumberField(key, (Long) value);
+            else if (value instanceof Short) generator.writeNumberField(key, (Short) value);
+            else if (value instanceof Float) generator.writeNumberField(key, (Float) value);
+            else if (value instanceof Double) generator.writeNumberField(key, (Double) value);
+            else if (value instanceof BigDecimal) generator.writeNumberField(key, (BigDecimal) value);
+            else if (value instanceof BigInteger) generator.writeNumberField(key, (BigInteger) value);
+            else generator.writeObjectField(key, value);
+        }
+    }
+}

--- a/src/test/java/net/logstash/logback/composite/KeyValueAttributeLogstashJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/KeyValueAttributeLogstashJsonProviderTest.java
@@ -1,0 +1,199 @@
+package net.logstash.logback.composite;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.KeyValuePair;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+
+import static ch.qos.logback.classic.Level.INFO;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeyValueAttributeLogstashJsonProviderTest {
+    private KeyValueAttributeLogstashJsonProvider provider = new KeyValueAttributeLogstashJsonProvider();
+
+    private ByteArrayOutputStream resultStream;
+    private JsonGenerator generator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        resultStream = new ByteArrayOutputStream();
+        generator = new JsonFactory().createGenerator(resultStream);
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithStringValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", "some string value"));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":\"some string value\"}");
+    }
+
+    @Test
+    void writesTwoKeyValuePairsWithStringValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key1", "first string value"));
+        event.getKeyValuePairs().add(new KeyValuePair("key2", "second string value"));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key1\":\"first string value\",\"key2\":\"second string value\"}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithBooleanValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", true));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":true}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithIntegerValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", 2147483646));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":2147483646}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithLongValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", 9223372036854775806L));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":9223372036854775806}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithShortValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", 32766));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":32766}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithFloatValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", Float.MAX_VALUE));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":3.4028235E38}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithDoubleValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", Double.MAX_VALUE));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":1.7976931348623157E308}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithBigDecimalValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(
+                new KeyValuePair(
+                        "key",
+                        BigDecimal.valueOf(Long.MAX_VALUE).add(BigDecimal.ONE).add(BigDecimal.valueOf(0.5))
+                )
+        );
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":9223372036854775808.5}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithBigIntegerValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE)));
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .isEqualTo("{\"key\":9223372036854775808}");
+    }
+
+    @Test
+    void writesSingleKeyValuePairWithRegularClassInstanceThatHasPropertiesAsValue() throws Exception {
+        LoggingEvent event = loggingEvent(INFO, "loggerName");
+        event.getKeyValuePairs().add(new KeyValuePair("key", new RegularValue(0, "value", "other value")));
+
+        generator.setCodec(new ObjectMapper());
+
+        write(event);
+
+        assertThat(resultStream.toString())
+                .describedAs("should write publicly accessible values")
+                .isEqualTo("{\"key\":{\"id\":0,\"value\":\"value\"}}");
+    }
+
+    private void write(LoggingEvent event) throws Exception {
+        generator.writeStartObject();
+        provider.writeTo(generator, event);
+        generator.writeEndObject();
+        generator.flush();
+    }
+
+    private static LoggingEvent loggingEvent(Level level, String message) throws Exception {
+        LoggingEvent loggingEvent = new LoggingEvent();
+        loggingEvent.setLoggerName("someLoggerName");
+        loggingEvent.setLevel(level);
+        loggingEvent.setMessage(message);
+        loggingEvent.setArgumentArray(new Object[]{});
+        loggingEvent.setKeyValuePairs(new ArrayList<>(4));
+
+        return loggingEvent;
+    }
+
+    private class RegularValue {
+        private final int id;
+        private final String value;
+        private final String nonPublicValue;
+
+        public RegularValue(int id, String value, String nonPublicValue) {
+            this.id = id;
+            this.value = value;
+            this.nonPublicValue = nonPublicValue;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Hi, maybe this provider could be a good start for supporting slf4j's key-value attributes:

It can be added to `logback.xml` like this:

```xml
<appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
    <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
      <providers>
        ...
        <provider
          class="net.logstash.logback.composite.KeyValueAttributeLogstashJsonProvider"/>
      </providers>
    </encoder>
  </appender>
```