### PR TITLE
Honor overriden `writeObject` of `JsonGenerator` passed to `setJsonGeneratorDecorator`

### DIFF
--- a/src/main/java/net/logstash/logback/composite/AbstractCompositeJsonFormatter.java
+++ b/src/main/java/net/logstash/logback/composite/AbstractCompositeJsonFormatter.java
@@ -302,7 +302,7 @@ public abstract class AbstractCompositeJsonFormatter<Event extends DeferredProce
     }
 
     private JsonGenerator decorateGenerator(JsonGenerator generator) {
-        JsonGenerator decorated = jsonGeneratorDecorator.decorate(generator)
+        JsonGenerator decorated = jsonGeneratorDecorator.decorate(new SimpleObjectJsonGeneratorDelegate(generator))
                 /*
                  * Don't let the json generator close the underlying outputStream and let the
                  * encoder managed it.
@@ -323,7 +323,7 @@ public abstract class AbstractCompositeJsonFormatter<Event extends DeferredProce
              */
         }
 
-        return new SimpleObjectJsonGeneratorDelegate(decorated);
+        return decorated;
     }
     
     public JsonFactory getJsonFactory() {


### PR DESCRIPTION
The order in which `JsonGeneratorDelegate`s are chained currently leads to disregard the `writeObject` method of the `JsonGenerator` passed to `setJsonGeneratorDecorator`.

The internal `SimpleObjectJsonGeneratorDelegate` indeed intercepts `writeObject` for quite a number of concrete types:
https://github.com/logfellow/logstash-logback-encoder/blob/933a0f51c1bfefc838adee9982ad3537a08a39bd/src/main/java/net/logstash/logback/util/SimpleObjectJsonGeneratorDelegate.java#L38-L60
```java
// etc.
```

The present change therefore consists in moving any user-defined `JsonGenerator` to the top level of the delegation chain, leaving users the power (and therefore the responsibility) to adjust the output to their needs.