### PR TITLE
Drop support for logback 1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,6 @@ jobs:
       - name: Test Jackson 2.12.x
         run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml -Pcompat-jackson surefire:test
 
-      # Run tests against Logback 1.2 to ensure runtime compatibility (do not recompile)
-      - name: Test Logback 1.2.x
-        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml -Pcompat-logback surefire:test
-
       - name: Upload Test Reports to Github
         uses: actions/upload-artifact@v3
         if: ${{ always() }}

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Maven style:
 <dependency>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-classic</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.7</version>
     <!-- Use runtime scope if the project does not have any compile-time usage of logback,
          such as implementations of Appender, Encoder, Layout, TurboFilter, etc
     <scope>runtime</scope>
@@ -123,14 +123,14 @@ from the maven repository exist on the runtime classpath.
 Specifically, the following need to be available on the runtime classpath:
 
 * jackson-databind / jackson-core / jackson-annotations >= 2.12.0
-* logback-core >= 1.2.0
-* logback-classic >= 1.2.0 (required for logging _LoggingEvents_)
-* logback-access >= 1.2.0 (required for logging _AccessEvents_)
+* logback-core >= 1.3.0
+* logback-classic >= 1.3.0 (required for logging _LoggingEvents_)
+* logback-access >= 1.3.0 (required for logging _AccessEvents_)
 * slf4j-api (usually comes as a transitive dependency of logback-classic)
 * java-uuid-generator (required if the `uuid` provider is used)
 
 Older versions than the ones specified in the pom file _might_ work, but the versions in the pom file are what testing has been performed against.
-Support for logback versions prior to 1.2.0 was removed in logstash-logback-encoder 7.0.
+Support for logback versions prior to 1.3.0 was removed in logstash-logback-encoder 7.4.
 
 If you are using logstash-logback-encoder in a project (such as spring-boot) that also declares dependencies on any of the above libraries, you might need to tell maven explicitly which versions to use to avoid conflicts.
 You can do so using maven's [dependencyManagement](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Dependency_Management) feature.
@@ -138,7 +138,7 @@ For example, to ensure that maven doesn't pick different versions of logback-cor
 
 ```xml
 <properties>
-    <logback.version>1.3.0</logback.version>
+    <logback.version>1.3.7</logback.version>
 </properties>
 <dependencyManagement>
     <dependencies>
@@ -164,10 +164,10 @@ For example, to ensure that maven doesn't pick different versions of logback-cor
 ## Java Version Requirements
 
 | logstash-logback-encoder | Minimum Java Version supported |
-| ------------------------ | -------------------------------|
-| &gt;= 6.0                | 1.8                            |
-| 5.x                      | 1.7                            |
-| &lt;= 4.x                | 1.6                            |
+|--------------------------|--------------------------------|
+| &gt;= 6.0                | 8                              |
+| 5.x                      | 7                              |
+| &lt;= 4.x                | 6                              |
 
 
 ## Usage
@@ -1705,11 +1705,7 @@ The provider uses a standard Java DateTimeFormatter under the hood. However, spe
 * `[ISO_INSTANT]`
 
 
-Note that the precision of the timestamp depends on the Logback version being used:
-- versions before `1.3.0` have a timestamp with millisecond precision
-- nanosecond precision is available starting from Logback `1.3.0`
-The standard `[...]` formats will therefore output millis or nanos depending on which version of Logback is on the runtime classpath.
-
+With logback 1.3+ the timestamp will have millisecond precision.
 
 The formatter uses the default TimeZone of the host Java platform by default. You can change it like this:
 
@@ -2328,8 +2324,6 @@ When using the `LogstashEncoder`, `LogstashAccessEncoder` or a composite encoder
 
 Note that logback's xml configuration reader will [trim whitespace from xml element values](https://github.com/qos-ch/logback/blob/c2dcbfcfb4048d11d7e81cd9220efbaaccf931fa/logback-core/src/main/java/ch/qos/logback/core/joran/event/BodyEvent.java#L27-L37).  Therefore, if you want to end the prefix or suffix pattern with whitespace, first add the whitespace, and then add something like `%mdc{keyThatDoesNotExist}` after it.  For example `<pattern>your pattern %mdc{keyThatDoesNotExist}</pattern>`.  This will cause logback to output the whitespace as desired, and then a blank string for the MDC key that does not exist.
 
-> :warning: If you encounter the following warning: `A "net.logstash.logback.encoder.LogstashEncoder" object is not assignable to a "ch.qos.logback.core.Appender" variable.`, you are encountering a backwards incompatibilility introduced in logback 1.2.1.  Please vote for [LOGBACK-1326](https://jira.qos.ch/browse/LOGBACK-1326) and add a thumbs up to [PR#383](https://github.com/qos-ch/logback/pull/383) to try to get this addressed in logback.  In the meantime, the only solution is to downgrade logback-classic and logback-core to 1.2.0
-
 The line separator, which is written after the suffix, can be specified as:
 * `SYSTEM` (uses the system default)
 * `UNIX` (uses `\n`)
@@ -2446,10 +2440,8 @@ The provider name is the xml element name to use when configuring.
       <td>
         <p>Event sequence number.
         </p>
-        <p>With Logback 1.3 the sequence number is obtained from the event itself as long as the LoggerContext is configured with a `SequenceNumberGenerator` (which is not by default).
+        <p>With Logback 1.3+ the sequence number is obtained from the event itself as long as the LoggerContext is configured with a `SequenceNumberGenerator` (which is not by default).
 If no SequenceNumberGenerator is configured, the provider emits a warning and reverts to a locally generated incrementing number starting at 1.
-        </p>
-        <p>With Logback versions prior to 1.3 the sequence number is generated locally by the provider itself.
         </p>
         <ul>
           <li><tt>fieldName</tt> - Output field name (<tt>sequence</tt>)</li>

--- a/pom.xml
+++ b/pom.xml
@@ -762,17 +762,6 @@
         </profile>
         
         <!--
-            Profile used to run backward compatibility tests against logback 1.2
-        -->
-        <profile>
-            <id>compat-logback</id>
-            <properties>
-                <logback.version>1.2.11</logback.version>
-                <surefire.reportsSubDir>logback-${logback.version}</surefire.reportsSubDir>
-            </properties>
-        </profile>
-        
-        <!--
             Profile used to run backward compatibility tests against jackson 2.12
         -->
         <profile>

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProvider.java
@@ -19,7 +19,6 @@ import java.time.Instant;
 
 import net.logstash.logback.composite.AbstractFormattedTimestampJsonProvider;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 
@@ -27,12 +26,7 @@ public class LoggingEventFormattedTimestampJsonProvider extends AbstractFormatte
     
     @Override
     protected Instant getTimestampAsInstant(ILoggingEvent event) {
-        if (LogbackUtils.isVersion13()) {
-            return event.getInstant();
-        }
-        else {
-            return Instant.ofEpochMilli(event.getTimeStamp());
-        }
+        return event.getInstant();
     }
 
 }

--- a/src/main/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProvider.java
@@ -23,7 +23,6 @@ import net.logstash.logback.composite.AbstractJsonProvider;
 import net.logstash.logback.composite.JsonProvider;
 import net.logstash.logback.marker.LogstashMarker;
 import net.logstash.logback.marker.Markers;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -35,15 +34,9 @@ import org.slf4j.Marker;
  */
 public class LogstashMarkersJsonProvider extends AbstractJsonProvider<ILoggingEvent> {
 
-    @SuppressWarnings("deprecation")
     @Override
     public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
-        if (LogbackUtils.isVersion13()) {
-            writeLogstashMarkerIfNecessary(generator, event.getMarkerList());
-        }
-        else {
-            writeLogstashMarkerIfNecessary(generator, event.getMarker());
-        }
+        writeLogstashMarkerIfNecessary(generator, event.getMarkerList());
     }
     
     private void writeLogstashMarkerIfNecessary(JsonGenerator generator, List<Marker> markers) throws IOException {

--- a/src/main/java/net/logstash/logback/composite/loggingevent/TagsJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/TagsJsonProvider.java
@@ -23,7 +23,6 @@ import net.logstash.logback.composite.AbstractFieldJsonProvider;
 import net.logstash.logback.composite.FieldNamesAware;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
 import net.logstash.logback.marker.LogstashMarker;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -32,8 +31,8 @@ import org.slf4j.Marker;
 /**
  * Writes {@link Marker} names as an array to the 'tags' field.
  * 
- * Does not write any special {@link LogstashMarker}s
- * (Those are handled by {@link LogstashMarkersJsonProvider}).
+ * <p>Does not write any special {@link LogstashMarker}s
+ * (Those are handled by {@link LogstashMarkersJsonProvider}).</p>
  */
 public class TagsJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> implements FieldNamesAware<LogstashFieldNames> {
 
@@ -43,21 +42,15 @@ public class TagsJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> i
         setFieldName(FIELD_TAGS);
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void writeTo(JsonGenerator generator, ILoggingEvent event) throws IOException {
         /*
          * Don't write the tags field unless we actually have a tag to write.
          */
         boolean hasWrittenStart = false;
-        
-        if (LogbackUtils.isVersion13()) {
-            hasWrittenStart = writeTagIfNecessary(generator, hasWrittenStart, event.getMarkerList());
-        }
-        else {
-            hasWrittenStart = writeTagIfNecessary(generator, hasWrittenStart, event.getMarker());
-        }
-        
+
+        hasWrittenStart = writeTagIfNecessary(generator, hasWrittenStart, event.getMarkerList());
+
         if (hasWrittenStart) {
             generator.writeEndArray();
         }

--- a/src/main/java/net/logstash/logback/util/LogbackUtils.java
+++ b/src/main/java/net/logstash/logback/util/LogbackUtils.java
@@ -15,37 +15,16 @@
  */
 package net.logstash.logback.util;
 
-import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.core.Context;
 import ch.qos.logback.core.spi.ContextAware;
 import ch.qos.logback.core.spi.LifeCycle;
 
 public abstract class LogbackUtils {
 
-    private static final boolean IS_VERSION_13 = hasMethod(LoggerContext.class, "getSequenceNumberGenerator");
-    
     private LogbackUtils() {
         // utility class
     }
-    
-    private static boolean hasMethod(Class<?> clazz, String name, Class<?>... args) {
-        try {
-            return clazz.getMethod(name, args) != null;
-        }
-        catch (NoSuchMethodException e) {
-            return false;
-        }
-    }
 
-    /**
-     * Indicate if Logback is at least version 1.3
-     * 
-     * @return {@code true} if Logback is at least version 1.3.0, {@code false} otherwise.
-     */
-    public static boolean isVersion13() {
-        return IS_VERSION_13;
-    }
-    
     public static void start(Object component) {
         if (component instanceof LifeCycle) {
             ((LifeCycle) component).start();

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LoggingEventFormattedTimestampJsonProviderTest.java
@@ -26,7 +26,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
 
 import net.logstash.logback.composite.AbstractFormattedTimestampJsonProvider;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -42,23 +41,16 @@ public class LoggingEventFormattedTimestampJsonProviderTest {
     @Mock
     private JsonGenerator generator;
 
-    @Mock(lenient = true)
+    @Mock(strictness = Mock.Strictness.LENIENT)
     private ILoggingEvent event;
 
     private Instant now;
     
     @BeforeEach
     public void setup() {
-        // Logback has nano precision since version 1.3
-        if (LogbackUtils.isVersion13()) {
-            now = Instant.now();
-            when(event.getTimeStamp()).thenReturn(now.toEpochMilli());
-            when(event.getInstant()).thenReturn(now);
-        }
-        else {
-            now = Instant.ofEpochMilli(System.currentTimeMillis());
-            when(event.getTimeStamp()).thenReturn(now.toEpochMilli());
-        }
+        now = Instant.now();
+        when(event.getTimeStamp()).thenReturn(now.toEpochMilli());
+        when(event.getInstant()).thenReturn(now);
     }
     
     

--- a/src/test/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/LogstashMarkersJsonProviderTest.java
@@ -18,16 +18,13 @@ package net.logstash.logback.composite.loggingevent;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
 import net.logstash.logback.marker.LogstashMarker;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.LoggingEvent;
 import com.fasterxml.jackson.core.JsonGenerator;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -47,12 +44,11 @@ public class LogstashMarkersJsonProviderTest {
 
     
     @Test
-    public void noMarkers() throws IOException {
+    public void noMarkers() {
         LoggingEvent event = createEvent();
         assertThatCode(() -> provider.writeTo(generator, event)).doesNotThrowAnyException();
     }
-    
-    
+
     /*
      * 
      */
@@ -83,8 +79,6 @@ public class LogstashMarkersJsonProviderTest {
     
     @Test
     public void multipleMarkers() throws IOException {
-        Assumptions.assumeTrue(LogbackUtils::isVersion13);
-        
         // event:
         //  * basic1 -> marker1
         //  * marker2
@@ -114,28 +108,18 @@ public class LogstashMarkersJsonProviderTest {
         return spy(new TestLogstashMarker(Integer.toString(this.markerCount++)));
     }
     
-    @SuppressWarnings("deprecation")
     private LoggingEvent createEvent(Marker... markers) {
         LoggingEvent event = spy(new LoggingEvent());
         
         if (markers != null && markers.length > 0) {
-            if (LogbackUtils.isVersion13()) {
-                for (Marker marker: markers) {
-                    event.addMarker(marker);
-                }
-            }
-            else {
-                if (markers.length > 1) {
-                    throw new IllegalStateException("Logback 1.2 supports only one Marker per event");
-                }
-                when(event.getMarker()).thenReturn(markers[0]);
+            for (Marker marker: markers) {
+                event.addMarker(marker);
             }
         }
         
         return event;
     }
     
-    @SuppressWarnings("serial")
     private static class TestLogstashMarker extends LogstashMarker {
         TestLogstashMarker(String name) {
             super(name);

--- a/src/test/java/net/logstash/logback/composite/loggingevent/SequenceJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/SequenceJsonProviderTest.java
@@ -28,12 +28,10 @@ import java.io.IOException;
 import java.util.function.Function;
 
 import net.logstash.logback.test.AbstractLogbackTest;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.spi.SequenceNumberGenerator;
 import com.fasterxml.jackson.core.JsonGenerator;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -89,8 +87,6 @@ public class SequenceJsonProviderTest extends AbstractLogbackTest {
     
     @Test
     public void testNoSequenceGeneratorInContext() throws IOException {
-        Assumptions.assumeTrue(LogbackUtils.isVersion13());
-        
         context.setSequenceNumberGenerator(null);
         provider.setContext(context);
         provider.start();
@@ -113,8 +109,6 @@ public class SequenceJsonProviderTest extends AbstractLogbackTest {
     
     @Test
     public void testSequenceGeneratorInContext() throws IOException {
-        Assumptions.assumeTrue(LogbackUtils.isVersion13());
-        
         // Set a SequenceNumberGenerator to the context
         SequenceNumberGenerator seqGenerator = mock(SequenceNumberGenerator.class);
         context.setSequenceNumberGenerator(seqGenerator);
@@ -158,8 +152,6 @@ public class SequenceJsonProviderTest extends AbstractLogbackTest {
         verify(generator).writeNumberField(SequenceJsonProvider.FIELD_SEQUENCE, 456L);
         
         verify(sequenceProvider).apply(event);
-        if (LogbackUtils.isVersion13()) {
-            verify(event, never()).getSequenceNumber();
-        }
+        verify(event, never()).getSequenceNumber();
     }
 }

--- a/src/test/java/net/logstash/logback/composite/loggingevent/TagsJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/TagsJsonProviderTest.java
@@ -17,13 +17,11 @@ package net.logstash.logback.composite.loggingevent;
 
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
 import net.logstash.logback.fieldnames.LogstashFieldNames;
 import net.logstash.logback.marker.LogstashMarker;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
@@ -64,8 +62,6 @@ public class TagsJsonProviderTest {
         
         marker4 = createBasicMarker("marker4");
 
-        // Logback 1.3: both markers are added to the event
-        // Logback 1.2: only marker1 is added to the event
         event = createEvent(marker1, marker4);
     }
     
@@ -79,9 +75,7 @@ public class TagsJsonProviderTest {
         inOrder.verify(generator).writeArrayFieldStart(TagsJsonProvider.FIELD_TAGS);
         inOrder.verify(generator).writeString("marker1");
         inOrder.verify(generator).writeString("marker3");
-        if (LogbackUtils.isVersion13()) {
-            inOrder.verify(generator).writeString("marker4");
-        }
+        inOrder.verify(generator).writeString("marker4");
         inOrder.verify(generator).writeEndArray();
         
         Mockito.verifyNoMoreInteractions(generator);
@@ -98,9 +92,7 @@ public class TagsJsonProviderTest {
         inOrder.verify(generator).writeArrayFieldStart("newFieldName");
         inOrder.verify(generator).writeString("marker1");
         inOrder.verify(generator).writeString("marker3");
-        if (LogbackUtils.isVersion13()) {
-            inOrder.verify(generator).writeString("marker4");
-        }
+        inOrder.verify(generator).writeString("marker4");
         inOrder.verify(generator).writeEndArray();
         
         Mockito.verifyNoMoreInteractions(generator);
@@ -119,9 +111,7 @@ public class TagsJsonProviderTest {
         inOrder.verify(generator).writeArrayFieldStart("newFieldName");
         inOrder.verify(generator).writeString("marker1");
         inOrder.verify(generator).writeString("marker3");
-        if (LogbackUtils.isVersion13()) {
-            inOrder.verify(generator).writeString("marker4");
-        }
+        inOrder.verify(generator).writeString("marker4");
         inOrder.verify(generator).writeEndArray();
         
         Mockito.verifyNoMoreInteractions(generator);
@@ -138,25 +128,18 @@ public class TagsJsonProviderTest {
         return spy(new TestLogstashMarker(name));
     }
     
-    @SuppressWarnings("deprecation")
     private LoggingEvent createEvent(Marker... markers) {
         LoggingEvent event = spy(new LoggingEvent());
         
         if (markers != null && markers.length > 0) {
-            if (LogbackUtils.isVersion13()) {
-                for (Marker marker: markers) {
-                    event.addMarker(marker);
-                }
-            }
-            else {
-                when(event.getMarker()).thenReturn(markers[0]);
+            for (Marker marker: markers) {
+                event.addMarker(marker);
             }
         }
         
         return event;
     }
     
-    @SuppressWarnings("serial")
     private static class TestLogstashMarker extends LogstashMarker {
         TestLogstashMarker(String name) {
             super(name);

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -39,10 +39,8 @@ import java.util.TimeZone;
 import net.logstash.logback.composite.AbstractFormattedTimestampJsonProvider;
 import net.logstash.logback.composite.loggingevent.LoggingEventJsonProviders;
 import net.logstash.logback.decorate.JsonFactoryDecorator;
-import net.logstash.logback.decorate.JsonGeneratorDecorator;
 import net.logstash.logback.fieldnames.LogstashCommonFieldNames;
 import net.logstash.logback.fieldnames.ShortenedFieldNames;
-import net.logstash.logback.util.LogbackUtils;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.pattern.TargetLengthBasedClassNameAbbreviator;
@@ -75,12 +73,7 @@ public class LogstashEncoderTest {
 
     @BeforeEach
     public void setup() {
-        // Logback as nanos precision since version 1.3
-        if (LogbackUtils.isVersion13()) {
-            now = Instant.now();
-        } else {
-            now = Instant.ofEpochMilli(System.currentTimeMillis());
-        }
+        now = Instant.now();
     }
 
     @Test
@@ -137,13 +130,7 @@ public class LogstashEncoderTest {
             }
         });
 
-        encoder.setJsonGeneratorDecorator(new JsonGeneratorDecorator() {
-
-            @Override
-            public JsonGenerator decorate(JsonGenerator generator) {
-                return generator.useDefaultPrettyPrinter();
-            }
-        });
+        encoder.setJsonGeneratorDecorator(JsonGenerator::useDefaultPrettyPrinter);
 
         encoder.start();
 
@@ -721,21 +708,13 @@ public class LogstashEncoderTest {
         event.setMessage(message);
         event.setLevel(level);
 
-        if (LogbackUtils.isVersion13()) {
-            event.setInstant(now);
-        } else {
-            event.setTimeStamp(now.toEpochMilli());
-        }
+        event.setInstant(now);
 
         return spy(event);
     }
 
     private void addMarker(LoggingEvent event, Marker marker) {
-        if (LogbackUtils.isVersion13()) {
-            event.addMarker(marker);
-        } else {
-            when(event.getMarker()).thenReturn(marker);
-        }
+        event.addMarker(marker);
     }
 
     private static String buildMultiLineMessage(String lineSeparator) {


### PR DESCRIPTION
Drop support for logback 1.2 in preparation for upcoming support for keyValue pairs in slf4j 2 and logback 1.3