### PR TITLE
Exclude configured MDC keys from processing with MdcEntryWriters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,16 @@ Currently, MDC entry writers for the following value types are supported:
 To add your own MDC entry writer for other types or apply the manipulations only for specific fields
 you can write your own implementation of [`MdcEntryWriter`](src/main/java/net/logstash/logback/composite/loggingevent/mdc/MdcEntryWriter.java).
 
+Writing MDC entries with the `MdcEntryWriters` can be skipped for MDC keys matching an exclude pattern
+(which is a regular expression with the syntax of `java.util.regex.Pattern`):
+
+```xml
+<encoder class="net.logstash.logback.encoder.LogstashEncoder">
+    <mdcEntryWriterExcludeKeyPattern>(skipExactKey|skipPrefix\\..*)</mdcEntryWriterExcludeKeyPattern>
+</encoder>
+```
+By default, all MDC entries are written as String values.
+
 You can also replace the default MDC JSON provider with your own class extending from
 [`MdcJsonProvider`](src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java).
 Configuring your class as a [Custom JSON Provider](#custom-json-provider) will then replace

--- a/src/main/java/net/logstash/logback/LogstashFormatter.java
+++ b/src/main/java/net/logstash/logback/LogstashFormatter.java
@@ -333,6 +333,11 @@ public class LogstashFormatter extends LoggingEventCompositeJsonFormatter {
             mdcProvider.addMdcEntryWriter(mdcEntryWriter);
         }
     }
+    public void setMdcEntryWriterExcludeKeyPattern(String mdcEntryWriterExcludeKeyPattern) {
+        if (isIncludeMdc()) {
+            mdcProvider.setMdcEntryWriterExcludeKeyPattern(mdcEntryWriterExcludeKeyPattern);
+        }
+    }
 
     public List<String> getIncludeKeyValueKeyNames() {
         return isIncludeKeyValuePairs()

--- a/src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java
@@ -200,7 +200,7 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> im
      * @param mdcKey    the key of the MDC map entry.
      * @param mdcValue  the value of the MDC map entry.
      */
-    private void writeMdcEntry(JsonGenerator generator, String fieldName, String mdcKey, String mdcValue) throws IOException {
+    protected void writeMdcEntry(JsonGenerator generator, String fieldName, String mdcKey, String mdcValue) throws IOException {
         if (shouldWrite(mdcKey)) {
             for (MdcEntryWriter mdcEntryWriter : this.mdcEntryWriters) {
                 if (mdcEntryWriter.writeMdcEntry(generator, fieldName, mdcKey, mdcValue)) {
@@ -213,7 +213,7 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> im
         generator.writeObject(mdcValue);
     }
 
-    private boolean shouldWrite(String mdcKey) {
+    protected boolean shouldWrite(String mdcKey) {
         return !this.mdcEntryWriters.isEmpty()
                 && (mdcEntryWriterExcludeKeyPattern == null || !mdcEntryWriterExcludeKeyPattern.matcher(mdcKey).matches());
     }

--- a/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
+++ b/src/main/java/net/logstash/logback/encoder/LogstashEncoder.java
@@ -119,6 +119,10 @@ public class LogstashEncoder extends LoggingEventCompositeJsonEncoder {
         getFormatter().addMdcEntryWriter(mdcEntryWriter);
     }
 
+    public void setMdcEntryWriterExcludeKeyPattern(String mdcEntryWriterExcludeKeyPattern) {
+        getFormatter().setMdcEntryWriterExcludeKeyPattern(mdcEntryWriterExcludeKeyPattern);
+    }
+
     public boolean isIncludeKeyValuePairs() {
         return getFormatter().isIncludeKeyValuePairs();
     }

--- a/src/main/java/net/logstash/logback/layout/LogstashLayout.java
+++ b/src/main/java/net/logstash/logback/layout/LogstashLayout.java
@@ -109,6 +109,10 @@ public class LogstashLayout extends LoggingEventCompositeJsonLayout {
         getFormatter().addMdcEntryWriter(mdcEntryWriter);
     }
 
+    public void setMdcEntryWriterExcludeKeyPattern(String mdcEntryWriterExcludeKeyPattern) {
+        getFormatter().setMdcEntryWriterExcludeKeyPattern(mdcEntryWriterExcludeKeyPattern);
+    }
+
     public boolean isIncludeKeyValuePairs() {
         return getFormatter().isIncludeKeyValuePairs();
     }

--- a/src/test/java/net/logstash/logback/ConfigurationTest.java
+++ b/src/test/java/net/logstash/logback/ConfigurationTest.java
@@ -182,6 +182,8 @@ public class ConfigurationTest {
         assertThat(mdcJsonProvider.getMdcKeyFieldNames()).containsOnly(entry("key", "renamedKey"));
         assertThat(mdcJsonProvider.getMdcEntryWriters()).hasSize(1);
         assertThat(mdcJsonProvider.getMdcEntryWriters()).element(0).isExactlyInstanceOf(LongMdcEntryWriter.class);
+        assertThat(mdcJsonProvider.getMdcEntryWriterExcludeKeyPattern()).isNotNull();
+        assertThat(mdcJsonProvider.getMdcEntryWriterExcludeKeyPattern().matcher("skipMe")).matches();
 
         KeyValuePairsJsonProvider keyValuePairsJsonProvider = getInstance(providers, KeyValuePairsJsonProvider.class);
         assertThat(keyValuePairsJsonProvider).isNotNull();

--- a/src/test/java/net/logstash/logback/composite/loggingevent/MdcJsonProviderTest.java
+++ b/src/test/java/net/logstash/logback/composite/loggingevent/MdcJsonProviderTest.java
@@ -187,4 +187,29 @@ public class MdcJsonProviderTest {
         verifyNoMoreInteractions(generator);
     }
 
+    @Test
+    public void testMdcEntryWritersExcludeKeyPattern() throws IOException {
+        mdc = new LinkedHashMap<>();
+        mdc.put("long", "1");
+        mdc.put("skip_exact", "2");
+        mdc.put("skip_prefix.key", "3");
+        mdc.put("axe", "4");
+        when(event.getMDCPropertyMap()).thenReturn(mdc);
+
+        provider.addMdcEntryWriter(new LongMdcEntryWriter());
+        provider.setMdcEntryWriterExcludeKeyPattern("(skip_prefix\\..*|skip_exact|.x.)");
+
+        provider.writeTo(generator, event);
+
+        verify(generator).writeFieldName("long");
+        verify(generator).writeNumber(1L);
+        verify(generator).writeFieldName("skip_exact");
+        verify(generator).writeObject("2");
+        verify(generator).writeFieldName("skip_prefix.key");
+        verify(generator).writeObject("3");
+        verify(generator).writeFieldName("axe");
+        verify(generator).writeObject("4");
+        verifyNoMoreInteractions(generator);
+    }
+
 }

--- a/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
+++ b/src/test/java/net/logstash/logback/encoder/LogstashEncoderTest.java
@@ -305,6 +305,7 @@ public class LogstashEncoderTest {
         mdcMap.put("double", "2.71828");
         mdcMap.put("bool", "true");
         mdcMap.put("default", "string");
+        mdcMap.put("skip_long", "-4711");
 
         LoggingEvent event = mockBasicILoggingEvent(Level.ERROR);
         event.setMDCPropertyMap(mdcMap);
@@ -312,6 +313,7 @@ public class LogstashEncoderTest {
         encoder.addMdcEntryWriter(new LongMdcEntryWriter());
         encoder.addMdcEntryWriter(new DoubleMdcEntryWriter());
         encoder.addMdcEntryWriter(new BooleanMdcEntryWriter());
+        encoder.setMdcEntryWriterExcludeKeyPattern("skip_.*");
         encoder.start();
         byte[] encoded = encoder.encode(event);
 
@@ -321,6 +323,7 @@ public class LogstashEncoderTest {
         assertThat(node.get("double").doubleValue()).isEqualTo(2.71828);
         assertThat(node.get("bool").booleanValue()).isTrue();
         assertThat(node.get("default").textValue()).isEqualTo("string");
+        assertThat(node.get("skip_long").textValue()).isEqualTo("-4711");
     }
 
     @Test

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -51,6 +51,7 @@
             <includeMdcKeyName>included</includeMdcKeyName>
             <mdcKeyFieldName>key=renamedKey</mdcKeyFieldName>
             <mdcEntryWriter class="net.logstash.logback.composite.loggingevent.mdc.LongMdcEntryWriter"/>
+            <mdcEntryWriterExcludeKeyPattern>skip.*</mdcEntryWriterExcludeKeyPattern>
             <includeKeyValueKeyName>included</includeKeyValueKeyName>
             <keyValueKeyFieldName>key=renamedKey</keyValueKeyFieldName>
             <customFields>{"customName":"customValue"}</customFields>
@@ -142,6 +143,7 @@
                     <includeMdcKeyName>included</includeMdcKeyName>
                     <mdcKeyFieldName>key=renamedKey</mdcKeyFieldName>
                     <mdcEntryWriter class="net.logstash.logback.composite.loggingevent.mdc.LongMdcEntryWriter"/>
+                    <mdcEntryWriterExcludeKeyPattern>skip.*</mdcEntryWriterExcludeKeyPattern>
                 </mdc>
                 <keyValuePairs>
                     <includeKeyName>included</includeKeyName>


### PR DESCRIPTION
@philsttr You were a little too fast with merging & releasing ;-)

Follow up for #957 providing a way to skip processing of the MdcEntryWriters.

The use for this comes into play as we have lots of services with a standard prefixed set of MDC keys for which for example the automatic MDC long-value writing should not happen.

And as a configuration is preferred over custom implementations, here's a proposal to configure this (with an exclude pattern).