### PR TITLE
Make MdcJsonProvider.writeMdcEntry() protected

### DIFF
--- a/src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/MdcJsonProvider.java
@@ -184,7 +184,7 @@ public class MdcJsonProvider extends AbstractFieldJsonProvider<ILoggingEvent> im
      * @param mdcKey    the key of the MDC map entry.
      * @param mdcValue  the value of the MDC map entry.
      */
-    private void writeMdcEntry(JsonGenerator generator, String fieldName, String mdcKey, String mdcValue) throws IOException {
+    protected void writeMdcEntry(JsonGenerator generator, String fieldName, String mdcKey, String mdcValue) throws IOException {
         for (MdcEntryWriter mdcEntryWriter : this.mdcEntryWriters) {
             if (mdcEntryWriter.writeMdcEntry(generator, fieldName, mdcKey, mdcValue)) {
                 return;


### PR DESCRIPTION
Follow up of #957 to make the writeMdcEntry() method protected.

In my former proposal the intention for the `protected` on the method in question was to allow an easier way to write a custom extension by extending from `MdcJsonProvider` and only overwriting what one wants to override.

Though there's no obligation to do so for a custom handler, it would be nicer as it already provides useful functions that a custom `MdcJsonProvider` would need as well.

A dependency is there regardless if the methods are `private` or `protected`. However, opening up some of the (private) methods would make customer handlers easier as some of the inner framework methods are very hard to reach otherwise.

Having it `private` would enforce to copy a redundant version of some of the inner workings. Though from the perspective of the framework, the inner workings are often black-boxed. But from the perspective of a client writing a custom handler it's more cumbersome to rewrite part of the code to fulfill a similar or exact purpose.
