### PR TITLE
Set AbstractThrowableClassNameJsonProvider.getThrowable as protected

### DIFF
--- a/src/main/java/net/logstash/logback/composite/loggingevent/AbstractThrowableClassNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/AbstractThrowableClassNameJsonProvider.java
@@ -57,7 +57,7 @@ public abstract class AbstractThrowableClassNameJsonProvider extends AbstractFie
     /**
      * @return null if no appropriate throwable
      */
-    abstract IThrowableProxy getThrowable(IThrowableProxy throwable);
+    protected abstract IThrowableProxy getThrowable(IThrowableProxy throwable);
 
     public void setUseSimpleClassName(boolean useSimpleClassName) {
         this.useSimpleClassName = useSimpleClassName;

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableClassNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableClassNameJsonProvider.java
@@ -25,7 +25,7 @@ public class ThrowableClassNameJsonProvider extends AbstractThrowableClassNameJs
     }
 
     @Override
-    IThrowableProxy getThrowable(IThrowableProxy throwable) {
+    protected IThrowableProxy getThrowable(IThrowableProxy throwable) {
         return throwable;
     }
 }

--- a/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableRootCauseClassNameJsonProvider.java
+++ b/src/main/java/net/logstash/logback/composite/loggingevent/ThrowableRootCauseClassNameJsonProvider.java
@@ -30,7 +30,7 @@ public class ThrowableRootCauseClassNameJsonProvider extends AbstractThrowableCl
     }
 
     @Override
-    IThrowableProxy getThrowable(IThrowableProxy throwable) {
+    protected IThrowableProxy getThrowable(IThrowableProxy throwable) {
         return throwable == null ? null : ThrowableSelectors.rootCause(throwable);
     }
 }


### PR DESCRIPTION
Hi, I'm trying to customize the `throwable_class` field name but I found out that it isn't possible to extend the class `AbstractThrowableClassNameJsonProvider` because its abstract method `getThrowable` is package protected.

I think it doesn't make much sense to have a public abstract class that isn't really publicly extendable. Also this should align the class with the similar `AbstractThrowableMessageJsonProvider`, which already has its abstract method as protected.

As a temporary workaround I'm extending the class `ThrowableClassNameJsonProvider`, this way the package protected method is already implemented and the problem is circumvented.

Let me know what you think about this!

Bye!