### PR TITLE
Always build source jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,9 +294,23 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>attach-javadocs</id>
                         <phase>package</phase>
                         <goals>
                             <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -721,6 +735,7 @@
             <id>fast</id>
             <properties>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
+                <maven.source.skip>true</maven.source.skip>
                 <license.skip>true</license.skip>
                 <checkstyle.skip>true</checkstyle.skip>
             </properties>


### PR DESCRIPTION
There was a regression introduced in 8.0 when building the source jar during releases when the maven-release-plugin was upgraded.

To simplify things, and avoid that in the future, I changed the build to always package the source jar.

Fixes #1036