### PR TITLE
Update LoggingEventJsonPatternParser to fix breaking logback change

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ from the maven repository exist on the runtime classpath.
 Specifically, the following need to be available on the runtime classpath:
 
 * jackson-databind / jackson-core / jackson-annotations >= 2.17.0
-* logback-core >= 1.5.0
-* logback-classic >= 1.5.0 (required for logging _LoggingEvents_)
-* logback-access >= 2.0.0 (required for logging _AccessEvents_)
+* logback-core >= 1.5.18
+* logback-classic >= 1.5.18 (required for logging _LoggingEvents_)
+* logback-access >= 2.0.6 (required for logging _AccessEvents_)
 * slf4j-api (usually comes as a transitive dependency of logback-classic)
 * java-uuid-generator (required if the `uuid` provider is used)
 

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <!-- runtime dependencies -->
         <jackson.version>2.17.2</jackson.version>
         <java-uuid-generator.version>5.1.0</java-uuid-generator.version>
-        <logback-core.version>1.5.6</logback-core.version>
-        <logback-access.version>2.0.2</logback-access.version>
+        <logback-core.version>1.5.18</logback-core.version>
+        <logback-access.version>2.0.6</logback-access.version>
 
         <!-- shaded runtime dependencies -->
         <disruptor.version>3.4.4</disruptor.version>
@@ -155,7 +155,7 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback.access</groupId>
-            <artifactId>common</artifactId>
+            <artifactId>logback-access-common</artifactId>
             <version>${logback-access.version}</version>
             <!--
                Required for logging IAccessEvents for access logs.
@@ -545,7 +545,7 @@
                         <links>   
                             <link>https://javadoc.io/doc/ch.qos.logback/logback-core/${logback-core.version}</link>
                             <link>https://javadoc.io/doc/ch.qos.logback/logback-classic/${logback-core.version}</link>
-                            <link>https://javadoc.io/doc/ch.qos.logback.access/common/${logback-access.version}</link>
+                            <link>https://javadoc.io/doc/ch.qos.logback.access/logback-access-common/${logback-access.version}</link>
                             
                             <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-core/${jackson.version}</link>
                             <link>https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/${jackson.version}</link>

--- a/src/main/java/net/logstash/logback/pattern/LoggingEventJsonPatternParser.java
+++ b/src/main/java/net/logstash/logback/pattern/LoggingEventJsonPatternParser.java
@@ -38,7 +38,7 @@ public class LoggingEventJsonPatternParser extends AbstractJsonPatternParser<ILo
     @Override
     protected PatternLayoutBase<ILoggingEvent> createLayout() {
         PatternLayoutBase<ILoggingEvent> layout = new PatternLayout();
-        layout.getInstanceConverterMap().put("property", EnhancedPropertyConverter.class.getName());
+        layout.getInstanceConverterMap().put("property", EnhancedPropertyConverter::new);
         return layout;
     }
 


### PR DESCRIPTION
Fixes #1060

Although this fixes the compatibility issue with logback 1.5.13, it does have breaking version compatibility changes (due to the underlying breaking change made by logback itself). I've updated the README to indicate new minimum versions, but I didn't change anything with the pom.xml version number, even though this might be worthy of a major version bump since it breaks backwards compatibility with logback versions.