### PR TITLE
Allow setting droppedWarnFrequency=0 to disable logging dropped message warnings

### DIFF
--- a/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
+++ b/src/test/java/net/logstash/logback/appender/AsyncDisruptorAppenderTest.java
@@ -207,7 +207,7 @@ public class AsyncDisruptorAppenderTest extends AbstractLogbackTest {
         final CountDownLatch eventHandlerWaiter = new CountDownLatch(1);
         TestEventHandler eventHandler = new TestEventHandler(eventHandlerWaiter);
 
-        appender.setShouldLogDroppedEvents(false);
+        appender.setDroppedWarnFrequency(0); // disable logging dropped events
         appender.setRingBufferSize(1);
         appender.setAppendTimeout(toLogback(Duration.ZERO)); // no timeout - drop when full
         appender.setEventHandler(eventHandler);


### PR DESCRIPTION
Currently there is no way to completely disable logging of dropped events. 

Using `droppedWarnFrequency` as suggested in the `README` isn't possible because setting the value to 0 will lead to a division by zero exception at [AsyncDisruptorAppender.java#L514](https://github.com/logfellow/logstash-logback-encoder/blob/main/src/main/java/net/logstash/logback/appender/AsyncDisruptorAppender.java#L514). 

>  When the appender drops an event, it emits a warning status message every droppedWarnFrequency consecutive dropped events (1000 by default, use 0 to turn off warnings). Another status message is emitted when the drop period is over and a first event is succesfully enqueued reporting the total number of events that were dropped.


Setting `droppedWarnFrequency` to something like `Integer.MAX_VALUE` doens't work either because the appender will emit how many total event that was dropped on the first successful enqueue after a ringbuffer full event.

This PR fixes it so that setting droppedWarnFrequency=0 will disable the log warnings, as mentioned in the readme