### PR TITLE
Bump minimum version of Java to 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17', '21' ]
+        java: [ '17', '21', '25' ]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
 
       - name: Setup GPG
         run: .github/workflows/steps/setup-gpg.sh

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ For example, to ensure that maven doesn't pick different versions of logback-cor
 
 | logstash-logback-encoder | Minimum Java Version supported |
 |--------------------------|--------------------------------|
+| 9.x                      | 17                             |
 | 8.x                      | 11                             |
 | 7.x                      | 8                              |
 | 6.x                      | 8                              |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.logstash.logback</groupId>
     <artifactId>logstash-logback-encoder</artifactId>
-    <version>8.2-SNAPSHOT</version>
+    <version>9.0-SNAPSHOT</version>
 
     <name>Logstash Logback Encoder</name>
     <description>Provides logback encoders, layouts, and appenders to log in JSON and other formats supported by Jackson</description>
@@ -19,7 +19,7 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- runtime dependencies -->
@@ -59,7 +59,7 @@
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <xml-maven-plugin.version>1.1.0</xml-maven-plugin.version>
 
-        <checkstyle.version>10.23.0</checkstyle.version>
+        <checkstyle.version>12.0.0</checkstyle.version>
 
         <!-- maven-javadoc-plugin configuration -->
         <maven.javadoc.failOnError>true</maven.javadoc.failOnError>


### PR DESCRIPTION
In preparation for Jackson 3 upgrade, bump the minimum version of Java to 17.

Bump major version

Bump checkstyle to 12.0.0

Add Java 25 to build matrix