### PR TITLE
Migrate artifact publishing to Maven Central Portal

### DIFF
--- a/.github/maven/settings.xml
+++ b/.github/maven/settings.xml
@@ -6,9 +6,9 @@
             <password>${env.GITHUB_TOKEN}</password>
         </server>
         <server>
-            <id>ossrh</id>
-            <username>${env.OSSRH_USERNAME}</username>
-            <password>${env.OSSRH_PASSWORD}</password>
+            <id>central</id>
+            <username>${env.CENTRAL_USERNAME}</username>
+            <password>${env.CENTRAL_PASSWORD}</password>
         </server>
     </servers>
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,8 @@ jobs:
             ${{ runner.os }}-maven-
 
       - name: Release
-        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml --activate-profiles ossrh release:prepare release:perform
+        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml --activate-profiles central-publish release:prepare release:perform
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -44,11 +44,10 @@ and uses the `maven-release-plugin` to perform the release, which then:
 2. Creates the git tag, and builds the artifacts
 3. Uses the `maven-gpg-plugin` to sign the artifacts with [this GPG signing key](http://keyserver.ubuntu.com/pks/lookup?search=0x794038C5C4DF6A3F&fingerprint=on&op=index)
    using the [`GPG_KEY` and `GPG_PASSPHRASE` secrets](https://github.com/logfellow/logstash-logback-encoder/settings/secrets/actions)
-4. Uses the `nexus-staging-maven-plugin` to:
-   1. Deploy the artifact to a staging repository hosted at https://oss.sonatype.org/
-      using the [`OSSRH_USERNAME` and `OSSRH_PASSWORD` secrets](https://github.com/logfellow/logstash-logback-encoder/settings/secrets/actions)
-   2. Automatically [release](https://central.sonatype.org/pages/releasing-the-deployment.html) the staging repository if no errors occur.
-      * After the staging repository is released, the new artifacts will eventually propagate to maven central. 
+4. Uses the `central-publishing-maven-plugin` to:
+   1. Upload the artifact to https://central.sonatype.com/
+      using the [`CENTRAL_USERNAME` and `CENTRAL_PASSWORD` secrets](https://github.com/logfellow/logstash-logback-encoder/settings/secrets/actions)
+   2. Automatically [publish](https://central.sonatype.org/pages/releasing-the-deployment.html) to maven central if no errors occur.
 5. Bumps the version to the next `-SNAPSHOT` version.
 
 After releasing, create a [release](https://github.com/logfellow/logstash-logback-encoder/releases) for the tag

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
 
         <!-- maven plugins -->
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+        <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <extra-enforcer-rules.version>1.11.0</extra-enforcer-rules.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
@@ -57,7 +58,6 @@
         <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>3.5.4</maven-surefire-plugin.version>
-        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <xml-maven-plugin.version>1.1.0</xml-maven-plugin.version>
 
         <checkstyle.version>12.0.0</checkstyle.version>
@@ -651,7 +651,7 @@
     </build>
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>central-publish</id>
             <build>
                 <plugins>
                     <plugin>
@@ -668,14 +668,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>${nexus-staging-maven-plugin.version}</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -787,16 +787,5 @@
             </properties>
         </profile>
     </profiles>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
Nexus OSSRH publishing was shutdown in June 2025.
Publish to the Maven Central Portal instead.

https://central.sonatype.org/pages/ossrh-eol