### PR TITLE
Switch release flow to manual GitHub action trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,51 +48,6 @@ jobs:
 
       - name: Upload Test Coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: matrix.java == '21'
+        if: matrix.java == '25'
         with:
           files: target/site/jacoco/jacoco.xml
-
-
-  release:
-    name: release
-    runs-on: ubuntu-24.04
-    needs: [build]
-    if: github.event_name == 'push' && github.repository == 'logfellow/logstash-logback-encoder' && github.ref == 'refs/heads/main' && startsWith(github.event.commits[0].message, '[release]')
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v3
-        with:
-          ref: main
-
-      - name: Setup JAVA
-        uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: 25
-
-      - name: Setup GPG
-        run: .github/workflows/steps/setup-gpg.sh
-        env:
-          GPG_KEY: ${{ secrets.GPG_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-
-      - name: Setup GIT
-        run: |
-          .github/workflows/steps/setup-git.sh
-          git switch main
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.m2/repository
-            ~/.m2/wrapper
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/wrapper/maven-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Release
-        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml --activate-profiles central-publish release:prepare release:perform
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: release
+
+on:
+  - workflow_dispatch
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-24.04
+    needs: [build]
+    if: github.repository == 'logfellow/logstash-logback-encoder' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: main
+
+      - name: Setup JAVA
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 25
+
+      - name: Setup GPG
+        run: .github/workflows/steps/setup-gpg.sh
+        env:
+          GPG_KEY: ${{ secrets.GPG_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Setup GIT
+        run: |
+          .github/workflows/steps/setup-git.sh
+          git switch main
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '.mvn/wrapper/maven-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Release
+        run: ./mvnw --batch-mode --no-transfer-progress --show-version --settings .github/maven/settings.xml --activate-profiles central-publish release:prepare release:perform
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -31,14 +31,13 @@ In other words, older releases will not be hotfixed, and backports will not be p
 Releasing
 ---------
 
-To perform a release, push a commit ([like this one](https://github.com/logfellow/logstash-logback-encoder/commit/aa942e9fe59320fa1b39f1b54f8a742dd8fd9930))
-to the `main` branch that:
+To perform a release, first, prepare the `main` branch:
+1. Set the version in the [pom.xml](pom.xml) to `X.Y-SNAPSHOT`, where `X.Y` is the version to be released. 
+2. Bump the version references in the [README.md](README.md)
 
-1. Bumps the version references in the README.md
-2. Contains a commit message that starts with `[release]`
+Then trigger the https://github.com/logfellow/logstash-logback-encoder/actions/workflows/release.yml on the main branch.
     
-The [build workflow](.github/workflows/build.yml) sees `[release]` in the commit message
-and uses the `maven-release-plugin` to perform the release, which then:
+The [release workflow](.github/workflows/release.yml) triggers a maven release via the `maven-release-plugin`, which then:
 
 1. Strips the `-SNAPSHOT` from the pom version,
 2. Creates the git tag, and builds the artifacts


### PR DESCRIPTION
Trigger releases explicitly in GitHub UI rather than pushing a commit