### PR TITLE
docs: fix 'succesfully' typo in ring buffer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,7 +737,7 @@ The behaviour of the appender when the RingBuffer is controlled by the `appendTi
 Logging threads waiting for space in the RingBuffer wake up periodically at a frequency starting at `1ns` and increasing exponentially up to `appendRetryFrequency` (default `5ms`). 
 Only one thread is allowed to retry at a time. If a thread is already retrying, additional threads are waiting on a lock until the first is finished. This strategy should help to limit CPU consumption while providing good enough latency and throughput when the ring buffer is at (or close) to its maximal capacity.
 
-When the appender drops an event, it emits a warning status message every `droppedWarnFrequency` consecutive dropped events (`1000` by default, use `0` to turn off warnings). Another status message is emitted when the drop period is over and a first event is succesfully enqueued reporting the total number of events that were dropped.
+When the appender drops an event, it emits a warning status message every `droppedWarnFrequency` consecutive dropped events (`1000` by default, use `0` to turn off warnings). Another status message is emitted when the drop period is over and a first event is successfully enqueued reporting the total number of events that were dropped.
 
 
 #### Graceful Shutdown


### PR DESCRIPTION
## Summary
Fixes a spelling typo in the ring-buffer / drop-period documentation: `succesfully` → `successfully`.

## Test plan
- [ ] Confirm the corrected sentence in the README reads correctly

Made with [Cursor](https://cursor.com)